### PR TITLE
genomes-clusters

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -56,7 +56,8 @@ def _get_clades_file_for_wildcards(wildcards):
 rule all:
     input:
         auspice_tree = expand("auspice/seattle_flu_seasonal_{lineage}_{segment}_{resolution}_global_tree.json", lineage=lineages, segment=segments, resolution=resolutions),
-        auspice_meta = expand("auspice/seattle_flu_seasonal_{lineage}_{segment}_{resolution}_global_meta.json", lineage=lineages, segment=segments, resolution=resolutions)
+        auspice_meta = expand("auspice/seattle_flu_seasonal_{lineage}_{segment}_{resolution}_global_meta.json", lineage=lineages, segment=segments, resolution=resolutions),
+        genomes = expand("results/genomes_{lineage}_cluster_{resolution}.fasta", lineage = lineages, resolution = resolutions)
 
 rule files:
     params:
@@ -450,18 +451,17 @@ rule clustering:
         """
 
 rule clusters_fasta:
-    message: "Creating fasta file of full-genome clusters"
+    message: "Creating fasta file of full-genome clusters. Outputs as genomes_lineage_cluster_resolution.fasta"
     input: 
-        clusters = "results/clustering_{lineage}_{resolution}.json",
-        nt_muts = expand("results/nt-muts_{{lineage}}_{segment}_{{resolution}}.json", segment=segments),
+        clusters = expand("results/clustering_{lineage}_{{resolution}}.json", lineage = lineages),
+        nt_muts = expand("results/nt-muts_{{lineage}}_{segment}_{{resolution}}.json", segment=segments)
     output:
-        sequences = 'results/genomes_{lineage}_{resolution}.fasta'
+        genomes = "results/genomes_{lineage}_cluster_{resolution}.fasta"
     shell:
         """
         python3 scripts/genomes_cluster.py \
             --clusters {input.clusters} \
-            --nt-muts {input.nt_muts} \
-            --output {output.sequences} \
+            --nt-muts {input.nt_muts} 
         """
 
 

--- a/Snakefile
+++ b/Snakefile
@@ -1,7 +1,7 @@
 from datetime import date
 from treetime.utils import numeric_date
 
-path_to_fauna = '../fauna'
+path_to_fauna = '../../fauna'
 if os.environ.get('FAUNA_PATH'):
     path_to_fauna = os.environ.get('FAUNA_PATH')
 

--- a/Snakefile
+++ b/Snakefile
@@ -449,6 +449,22 @@ rule clustering:
             --output {output.node_data}
         """
 
+rule clusters_fasta:
+    message: "Creating fasta file of full-genome clusters"
+    input: 
+        clusters = "results/clustering_{lineage}_{resolution}.json",
+        nt_muts = expand("results/nt-muts_{{lineage}}_{segment}_{{resolution}}.json", segment=segments),
+    output:
+        sequences = 'results/genomes_{lineage}_{resolution}.fasta'
+    shell:
+        """
+        python3 scripts/genomes_cluster.py \
+            --clusters {input.clusters} \
+            --nt-muts {input.nt_muts} \
+            --output {output.sequences} \
+        """
+
+
 # def _get_trees_for_all_segments(wildcards):
 #     trees = []
 #     for seg in segments:

--- a/config/cluster-gizmo.json
+++ b/config/cluster-gizmo.json
@@ -1,0 +1,62 @@
+{
+    "__default__": {
+        "time" : "00:15:00",
+        "cores" : 1,
+        "memory": "512",
+        "disk": "6000",
+        "name": "{rule}.{wildcards}",
+        "stdout": "log/cluster/{rule}.{wildcards}.%j.out",
+        "stderr": "log/cluster/{rule}.{wildcards}.%j.err"
+    },
+    "align_fauna_sequences_to_ncbi_database": {
+        "time": "4:00:00",
+        "memory": "16384",
+        "cores": 4
+    },
+    "align": {
+        "time": "0:30:00",
+        "memory": "16384",
+        "cores": 4
+    },
+    "tree": {
+        "time": "2:00:00",
+        "memory": "16384",
+        "cores": 4
+    },
+    "refine": {
+        "time": "2:00:00",
+        "memory": "16384"
+    },
+    "align_simulated": {
+        "time": "0:30:00",
+        "memory": "16384",
+        "cores": 4
+    },
+    "tree_simulated": {
+        "time": "2:00:00",
+        "memory": "16384",
+        "cores": 4
+    },
+    "refine_simulated": {
+        "time": "2:00:00",
+        "memory": "16384"
+    },
+    "ancestral": {
+        "time": "0:15:00",
+        "memory": "4096"
+    },
+    "cross_immunities": {
+        "memory": "8192"
+    },
+    "distances": {
+        "memory": "8192",
+        "time" : "00:30:00"
+    },
+    "fit_models_by_distances": {
+        "memory": "8192",
+        "time" : "00:30:00"
+    },
+    "plot_tree": {
+        "memory": "8192"
+    }
+}

--- a/scripts/genomes_cluster.py
+++ b/scripts/genomes_cluster.py
@@ -1,0 +1,93 @@
+
+'''
+Creates full-genome fasta files of clusters.
+'''
+import os
+import json
+
+
+'''
+Load .json clusters into python dictionary
+'''
+def clusters(file):
+    diction = {}
+    if os.path.isfile(file):
+        with open(file) as jfile:
+            json_data = json.load(jfile)
+            for strain, cluster_dict in json_data["nodes"].items():
+                for cluster_number in cluster_dict.values():
+                    if cluster_number in diction:
+                        diction[cluster_number].append(strain)
+                    else:
+                        diction[cluster_number] = [strain]
+    for cluster_num, strains in diction.items():
+        diction[cluster_num] = dict.fromkeys(strains, [])
+    return diction
+
+
+'''
+Loads sequences into python dictionary by cluster
+'''
+def data(files):
+    for fname in files:
+        if os.path.isfile(fname):
+            with open(fname) as jfile:
+                json_data = json.load(jfile)
+    return json_data
+
+
+def sequences(clusters, file):
+    data = clusters
+    for cluster_id, cluster_strains in clusters.items():
+        for strain, emptyset in cluster_strains.items():
+            if strain in file["nodes"].keys():
+                seq = file["nodes"][strain]["sequence"]
+                #if strain == 'A/Louisiana/1/2019':
+                 #   print(seq)
+                data[cluster_id][strain].append(seq)
+    return data
+
+#Create clusters dictionary
+y = clusters('clustering_h3n2_2y.json')
+
+#Create nt_muts list
+nt_muts = ['nt-muts_h3n2_ha_2y.json']
+
+#Makes data to feed into sequences
+z = data(nt_muts)
+#print(z)
+
+#There are not 335 of these strains with name "A/Calif..." in either z or y.
+#set = []
+#for strain in z["nodes"]:
+ #   if "A/California/141/2019" in strain:
+  #      set.append(1)
+#print(set)
+
+#print(z['nodes']['0622b49d-dada-40cb-9ba7-b7a75b0d9ab5'])
+
+#There is only one sequence associated with z['nodes'][c]
+for cluster_id, cluster_strains in y.items():
+    for strain, emptyset in cluster_strains.items():
+        if strain in z["nodes"].keys():
+            print(strain, y[cluster_id][strain])
+
+#Makes sequences dictionary
+#x = sequences(y, z)
+#print(x)
+#print([(cluster, strain, len(seqs)) for cluster, cluster_strains in x.items() for strain, seqs in cluster_strains.items()])
+#print([(cluster, len(cluster_strains)) for cluster, cluster_strains in x.items()]) 
+
+'''
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Create full-genome fasta files of clusters",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument('--clusters', nargs='+', type = str, required=True, help = "list of cluster JSON files")
+    args = parser.parse_args()
+
+    # print out dict
+    print(clusters(args.clusters))
+'''

--- a/scripts/genomes_cluster.py
+++ b/scripts/genomes_cluster.py
@@ -1,84 +1,57 @@
 
 '''
-Creates full-genome fasta files of clusters.
+Creates full-genome fasta files for each clusters.
 '''
 import os
 import json
-
+import argparse
 
 '''
-Load .json clusters into python dictionary
+Load clusters into usable python dictionary
 '''
-def clusters(file):
+def clusters(files):
     diction = {}
-    if os.path.isfile(file):
-        with open(file) as jfile:
+    for fname in files:
+        with open(fname) as jfile:
             json_data = json.load(jfile)
             for strain, cluster_dict in json_data["nodes"].items():
-                for cluster_number in cluster_dict.values():
-                    if cluster_number in diction:
-                        diction[cluster_number].append(strain)
-                    else:
-                        diction[cluster_number] = [strain]
-    for cluster_num, strains in diction.items():
-        diction[cluster_num] = dict.fromkeys(strains, [])
+                cluster_number = cluster_dict['cluster']
+                if cluster_number in diction:
+                    diction[cluster_number][strain] = []
+                else:
+                    diction[cluster_number] = {strain : []}
     return diction
 
 
 '''
-Loads sequences into python dictionary by cluster
+Adds sequences into python dictionary by cluster
 '''
-def data(files):
+def sequences(clusters, files):
     for fname in files:
-        if os.path.isfile(fname):
-            with open(fname) as jfile:
-                json_data = json.load(jfile)
-    return json_data
-
-
-def sequences(clusters, file):
-    data = clusters
+        with open(fname) as jfile:
+            json_data = json.load(jfile)
+            for cluster_id, cluster_strains in clusters.items():
+                for strain in cluster_strains.keys():
+                    if strain in json_data["nodes"].keys():
+                        seq = json_data["nodes"][strain]["sequence"]
+                        clusters[cluster_id][strain].append(seq)
     for cluster_id, cluster_strains in clusters.items():
-        for strain, emptyset in cluster_strains.items():
-            if strain in file["nodes"].keys():
-                seq = file["nodes"][strain]["sequence"]
-                #if strain == 'A/Louisiana/1/2019':
-                 #   print(seq)
-                data[cluster_id][strain].append(seq)
-    return data
+        for strain, sequence in cluster_strains.items():
+            clusters[cluster_id][strain] = ''.join(sequence)
+    return clusters
 
-#Create clusters dictionary
-y = clusters('clustering_h3n2_2y.json')
-
-#Create nt_muts list
-nt_muts = ['nt-muts_h3n2_ha_2y.json']
-
-#Makes data to feed into sequences
-z = data(nt_muts)
-#print(z)
-
-#There are not 335 of these strains with name "A/Calif..." in either z or y.
-#set = []
-#for strain in z["nodes"]:
- #   if "A/California/141/2019" in strain:
-  #      set.append(1)
-#print(set)
-
-#print(z['nodes']['0622b49d-dada-40cb-9ba7-b7a75b0d9ab5'])
-
-#There is only one sequence associated with z['nodes'][c]
-for cluster_id, cluster_strains in y.items():
-    for strain, emptyset in cluster_strains.items():
-        if strain in z["nodes"].keys():
-            print(strain, y[cluster_id][strain])
-
-#Makes sequences dictionary
-#x = sequences(y, z)
-#print(x)
-#print([(cluster, strain, len(seqs)) for cluster, cluster_strains in x.items() for strain, seqs in cluster_strains.items()])
-#print([(cluster, len(cluster_strains)) for cluster, cluster_strains in x.items()]) 
 
 '''
+Outputs python dictionary sequences into fasta files
+'''
+def genomes(seq_dict):
+    for cluster, cluster_strains in seq_dict.items():
+        with open ('results/genomes_{wildcards.lineage}_cluster'+cluster+'_{wildcards.resolution}.fasta', "w") as fasta: 
+            for strain, seq in cluster_strains.items():
+                fasta.write('>' + strain + ' | cluster'+cluster + '\n' + seq + '\n')
+        
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Create full-genome fasta files of clusters",
@@ -86,8 +59,15 @@ if __name__ == '__main__':
     )
 
     parser.add_argument('--clusters', nargs='+', type = str, required=True, help = "list of cluster JSON files")
+    parser.add_argument('--nt-muts', nargs='+', type =str, required=True, help = "list of nt-muts JSON files")
     args = parser.parse_args()
 
-    # print out dict
-    print(clusters(args.clusters))
-'''
+    #Create clusters dictionary
+    cluster_dict = clusters(args.clusters)
+
+    #Makes sequences dictionary
+    cluster_seq_dict = sequences(cluster_dict, args.nt_muts)
+
+    #Outputs fasta files
+    genomes(cluster_seq_dict)
+


### PR DESCRIPTION
#1 adds a `rule clusters_fasta` to the Snakefile, which uses `scripts/genomes_cluster.py` to produce full-genome fastas for each cluster. This still needs some troubleshooting. I think we need to generate the wildcards `{clusters}` from `rule clustering` and create a checkpoint there.

The "Adjusted Augur-build to..." commit should not be merged. In it, I updated the `Snakefile` to reference the location of fauna on my computer and to add `config/cluster-gizmo.json`, so I could run snakemake with slurm.