### PR TITLE
Min size

### DIFF
--- a/Snakefile_segments
+++ b/Snakefile_segments
@@ -455,6 +455,8 @@ rule clusters_fasta:
     input:
         clusters = rules.clustering.output.node_data,
         nt_muts = rules.clustering.input.nt_muts
+    params:
+        min_size = 2
     output:
         genomes = "clusters-data/{lineage}_{resolution}_cluster0.fasta"
     shell:
@@ -462,6 +464,7 @@ rule clusters_fasta:
         python3 scripts/extract_cluster_fastas.py \
             --clusters {input.clusters} \
             --nt-muts {input.nt_muts} \
+            --min-size {params.min_size} \
             --output {output.genomes}
         """
 

--- a/scripts/extract_cluster_fastas.py
+++ b/scripts/extract_cluster_fastas.py
@@ -7,7 +7,7 @@ import argparse
 '''
 Load clusters into usable python dictionary
 '''
-def clusters(file):
+def clusters(file, min_size):
     diction = {}
     with open(file) as jfile:
         json_data = json.load(jfile)
@@ -17,6 +17,10 @@ def clusters(file):
                 diction[cluster_number][strain] = []
             else:
                 diction[cluster_number] = {strain : []}
+    dict_scan = dict(diction)
+    for cluster_id, cluster_strains in dict_scan.items():
+        if len(cluster_strains) < min_size:
+            del diction[cluster_id]
     return diction
 
 
@@ -57,11 +61,12 @@ if __name__ == '__main__':
 
     parser.add_argument('--clusters', type = str, required = True, help = "cluster JSON files")
     parser.add_argument('--nt-muts', nargs = '+', type = str, required = True, help = "list of nt-muts JSON files")
+    parser.add_argument('--min-size', type = int, default = 2, help "Minimum number of strains in cluster. Default is 2.")
     parser.add_argument('--output', type = str, required = True, help = "output location")
     args = parser.parse_args()
 
     # Create clusters dictionary
-    cluster_dict = clusters(args.clusters)
+    cluster_dict = clusters(args.clusters, args.min_size)
 
     # Makes sequences dictionary
     cluster_seq_dict = sequences(cluster_dict, args.nt_muts)

--- a/scripts/extract_cluster_fastas.py
+++ b/scripts/extract_cluster_fastas.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--clusters', type = str, required = True, help = "cluster JSON files")
     parser.add_argument('--nt-muts', nargs = '+', type = str, required = True, help = "list of nt-muts JSON files")
-    parser.add_argument('--min-size', type = int, default = 2, help "Minimum number of strains in cluster. Default is 2.")
+    parser.add_argument('--min-size', type = int, default = 2, help = "Minimum number of strains in cluster. Default is 2.")
     parser.add_argument('--output', type = str, required = True, help = "output location")
     args = parser.parse_args()
 


### PR DESCRIPTION
#4 Adds `--min-size` parameter to `rule clusters fasta`. Default is set to 2, so each cluster must contain at least 2 strains in  order for a fasta file to be created.