### PR TITLE
Filtering-to-seattle

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -480,7 +480,7 @@ checkpoint clusters_fasta:
     input:
         clusters = rules.clustering.output.node_data,
         nt_muts = expand("results/nt-muts_{{lineage}}_{segment}_{{resolution}}.json", segment=segments),
-        metadata = expand(metadata = "data/background_metadata_{lineage}_{segment}.tsv", segment = segments)
+        metadata = expand("data/metadata_{{lineage}}_{segment}.tsv", segment = segments)
     params:
         min_size = 2
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -518,7 +518,7 @@ checkpoint clusters_fasta:
     message: "Creating directory of fasta files of full-genome clusters."
     input:
         clusters = rules.clustering.output.node_data,
-        nt_muts = expand("results/nt-muts_{{lineage}}_{segment}_{{resolution}}.json", segment=segments)
+        nt_muts = expand("results/nt-muts_{{lineage}}_{segment}_{{resolution}}.json", segment=segments),
         metadata = expand(metadata = "data/background_metadata_{lineage}_{segment}.tsv", segment = segments)
     params:
         min_size = 2

--- a/Snakefile
+++ b/Snakefile
@@ -519,6 +519,7 @@ checkpoint clusters_fasta:
     input:
         clusters = rules.clustering.output.node_data,
         nt_muts = expand("results/nt-muts_{{lineage}}_{segment}_{{resolution}}.json", segment=segments)
+        metadata = expand(metadata = "data/background_metadata_{lineage}_{segment}.tsv", segment = segments)
     params:
         min_size = 2
     output:
@@ -528,6 +529,7 @@ checkpoint clusters_fasta:
         python3 scripts/extract_cluster_fastas.py \
             --clusters {input.clusters} \
             --nt-muts {input.nt_muts} \
+            --metadata {input.metadata} \
             --min-size {params.min_size} \
             --output-dir {output.dir}
         """

--- a/scripts/extract_cluster_fastas.py
+++ b/scripts/extract_cluster_fastas.py
@@ -55,12 +55,10 @@ def filter_to_seattle(metadata_file, clusters):
             meta_strains_seattle = meta_file[meta_file["region"] == 'seattle']
             strains_seattle_list = meta_strains_seattle.loc[:,'strain'].tolist()
 
-
     for cluster, strain_att in clusters.items():
         check = any(strain in strain_att.keys() for strain in strains_seattle_list)
         if check:
             cluster_seattle.append(cluster)
-            print(cluster_seattle)
 
     final_clusters = clusters.copy()
 
@@ -90,7 +88,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--clusters', type = str, required = True, help = "cluster JSON files")
     parser.add_argument('--nt-muts', nargs = '+', type = str, required = True, help = "list of nt-muts JSON files")
-    parser.add_argument('--metadata', nargs='+', help="file with metadata associated with viral sequences, one for each segment")
+    parser.add_argument('--metadata', nargs = '+', type = str, required = True, help = "metadata of strains, one for each segment")
     parser.add_argument('--min-size', type = int, default = 2, help = "Minimum number of strains in cluster. Default is 2.")
     parser.add_argument('--output-dir', type = str, required = True, help = "output directory")
     args = parser.parse_args()

--- a/scripts/extract_cluster_fastas.py
+++ b/scripts/extract_cluster_fastas.py
@@ -4,6 +4,7 @@ Creates full-genome fasta files for each clusters.
 import os
 import json
 import argparse
+import pandas as pd
 
 '''
 Load clusters into usable python dictionary


### PR DESCRIPTION
This is in reference to #3

It attempts to select only for those clusters that have at least one strain from Seattle. Before the introduction of the checkpoints, it worked well for H3N2 but failed to work for H1N1. Still in the process of troubleshooting it but any suggestions would be helpful. The Nextstrain shell version of Snakemake didn't have "checkpoints" so I have yet to test it with the new changes but it doubt that it'll break because of it. Thomas is currently updating the Snakemake version in the nextstrain shell and I will try it again accordingly once the image finishes building