### PR TITLE
Updated H3N2 reference to A/Perth/16/2009.

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -11,7 +11,7 @@ lineages = ['h3n2', 'h1n1pdm']
 resolutions = ['2y']
 
 def reference_strain(wildcards):
-    references = {'h3n2':"A/Beijing/32/1992",
+    references = {'h3n2':"A/Perth/16/2009",
                   'h1n1pdm':"A/California/07/2009",
                   'vic':"B/HongKong/02/1993",
                   'yam':"B/Singapore/11/1994"
@@ -630,7 +630,6 @@ rule aggregate_cluster_trees:
             --trees {input.trees} \
             --output {output.tree}
         """
-
 rule clean:
     message: "Removing directories: {params}"
     params:

--- a/config/reference_h3n2_ha.gb
+++ b/config/reference_h3n2_ha.gb
@@ -1,88 +1,100 @@
-LOCUS       A/Beijing/32/1992               1701 bp    DNA              VRL 02-MAY-2006
-DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) hemagglutinin gene,
-            complete cds.
-ACCESSION   U26830
-VERSION     U26830.1  GI:857407
+LOCUS       KJ609206                1727 bp    cRNA    linear   VRL 25-MAR-2015
+DEFINITION  Influenza A virus (A/Perth/16/2009(H3N2)) segment 4 hemagglutinin
+            (HA) gene, complete cds.
+ACCESSION   KJ609206
+VERSION     KJ609206.1
 KEYWORDS    .
-SOURCE      Influenza A virus (A/Beijing/32/1992(H3N2))
-  ORGANISM  Influenza A virus (A/Beijing/32/1992(H3N2))
+SOURCE      Influenza A virus (A/Perth/16/2009(H3N2))
+  ORGANISM  Influenza A virus (A/Perth/16/2009(H3N2))
             Viruses; ssRNA viruses; ssRNA negative-strand viruses;
             Orthomyxoviridae; Influenzavirus A.
-REFERENCE   1  (bases 1 to 1701)
-  AUTHORS   Muster,T., Ferko,B., Klima,A., Purtscher,M., Trkola,A., Schulz,P.,
-            Grassauer,A., Engelhardt,O.G., Garcia-Sastre,A., Palese,P. and
-            Katinger,H.
-  TITLE     Mucosal model of immunization against human immunodeficiency virus
-            type 1 with a chimeric influenza virus
-  JOURNAL   J. Virol. 69 (11), 6678-6686 (1995)
-   PUBMED   7474077
-REFERENCE   2  (bases 1 to 1701)
-  AUTHORS   Muster,T. and Klima,A.
+REFERENCE   1  (bases 1 to 1727)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
+  TITLE     Innate immune response of BEAS-2B to influenza A (H3N2) viruses
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 1727)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
   TITLE     Direct Submission
-  JOURNAL   Submitted (11-MAY-1995) Thomas Muster, Institute of Applied
-            Microbiology, Nussdorfer Laende 11, Vienna, A-1190, Austria
+  JOURNAL   Submitted (14-MAR-2014) Office of Cyber Infrastructure and
+            Computational Biology, National Institute of Allergy and Infectious
+            Diseases, 31 Center Drive, Room 3B62, Bethesda, MD 20892, USA
+COMMENT     GenBank Accession Numbers KJ609203-KJ609210 represent sequences
+            from the 8 segments of Influenza A virus (A/Perth/16/2009(H3N2)).
+            
+            ##Assembly-Data-START##
+            Assembly Method       :: SOAPdenovo2-bin-LINUX-generic-r240
+            Coverage              :: 3903
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
-     source          1..1701
-                     /mol_type="genomic RNA"
-                     /lab_host="MDBK cells"
-                     /db_xref="taxon:380950"
+     source          1..1727
+                     /organism="Influenza A virus (A/Perth/16/2009(H3N2))"
+                     /mol_type="viral cRNA"
+                     /strain="A/Perth/16/2009"
                      /serotype="H3N2"
-                     /strain="A/Beijing/32/1992"
                      /host="Homo sapiens"
-                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
-     CDS             1..1701
-                     /db_xref="GI:857408"
-                     /product="hemagglutinin"
+                     /db_xref="taxon:654811"
+                     /segment="4"
+                     /country="Australia"
+                     /collection_date="07-Apr-2009"
+                     /note="passage details: E6, BEAS-2B 1"
+     misc_feature    1..1727
+                     /db_xref="IRD:IRD-Perth.4"
+     gene            9..1709
+                     /gene="HA"
+     CDS             9..1709
+                     /gene="HA"
+                     /function="receptor binding and fusion protein"
                      /codon_start=1
-                     /translation="MKTIIALSYILCLVFAQKLPGNDNSTATLCLGHHAVPNGTLVKTI
-                     TNDQIEVTNATELVQSSSTGRICDSPHRILDGKNCTLIDALLGDPHCDGFQNKEWDLFV
-                     ERSKAYSNCYPYDVPDYASLRSLVASSGTLEFINEDFNWTGVAQDGGSYACKRGSVNSF
-                     FSRLNWLHKSEYKYPALNVTMPNNGKFDKLYIWGVHHPSTDRDQTSLYVRASGRVTVST
-                     KRSQQTVTPNIGSRPWVRGQSSRISIYWTIVKPGDILLINSTGNLIAPRGYFKIRNGKS
-                     SIMRSDAPIGTCSSECITPNGSIPNDKPFQNVNRITYGACPRYVKQNTLKLATGMRNVP
-                     EKQTRGIFGAIAGFIENGWEGMVDGWYGFRHQNSEGTGQAADLKSTQAAIDQINGKLNR
-                     LIEKTNEKFHQIEKEFSEVEGRIQDLEKYVEDTKIDLWSYNAELLVALENQHTIDLTDS
-                     EMNKLFEKTRKQLRENAEDMGNGCFKIYHKCDNACIGSIRNGTYDHDVYRDEALNNRFQ
-                     IKGVELKSGYKDWILWISFAISCFLLCVVLLGFIMWACQKGNIRCNICI"
-                     /protein_id="AAA87553.1"
-     CDS             1..48
-                     /product="Signal peptide"
-                     /gene="SigPep"
-     CDS             49..1035
-                     /product="HA1 protein"
-                     /gene="HA1"
-     CDS             1036..1698
-                     /product="HA2 protein"
-                     /gene="HA2"
-
-ORIGIN
-        1 atgaagacta tcattgcttt gagctacatt ttatgtctgg ttttcgctca aaaacttccc
-       61 ggaaatgaca acagcacagc aacgctgtgc ctgggacatc atgcagtgcc aaacggaacg
-      121 ctagtgaaaa caatcacgaa tgatcaaatt gaagtgacta atgctactga gctggttcag
-      181 agttcctcaa caggtagaat atgcgacagt cctcaccgaa tccttgatgg aaaaaactgc
-      241 acactgatag atgctctatt gggagaccct cattgtgatg gcttccaaaa taaggaatgg
-      301 gacctttttg ttgaacgcag caaagcttac agcaactgtt acccttatga tgtaccggat
-      361 tatgcctccc ttaggtcact agttgcctca tcaggcaccc tggagtttat caatgaagac
-      421 ttcaattgga ctggagtcgc tcaggatggg ggaagctatg cttgcaaaag gggatctgtt
-      481 aacagtttct ttagtagatt gaattggttg cacaaatcag aatacaaata tccagcgctg
-      541 aacgtgacta tgccaaacaa tggcaaattt gacaaattgt acatttgggg ggttcaccac
-      601 ccgagcacgg acagagacca aaccagccta tatgttcgag catcagggag agtcacagtc
-      661 tctaccaaaa gaagccaaca aactgtaacc ccgaatatcg ggtctagacc ctgggtaagg
-      721 ggtcagtcca gtagaataag catctattgg acaatagtaa aaccgggaga catacttttg
-      781 attaatagca cagggaatct aattgctcct cggggttact tcaaaatacg aaatgggaaa
-      841 agctcaataa tgaggtcaga tgcacccatt ggcacctgca gttctgaatg catcactcca
-      901 aatggaagca ttcccaatga caaacctttt caaaatgtaa acaggatcac atatggggcc
-      961 tgccccagat atgttaagca aaacactctg aaattggcaa cagggatgcg gaatgtacca
-     1021 gagaaacaaa ctagaggcat attcggcgca atcgcaggtt tcatagaaaa tggttgggag
-     1081 ggaatggtag acggttggta cggtttcagg catcaaaatt ctgagggcac aggacaagca
-     1141 gcagatctta aaagcactca agcagcaatc gaccaaatca acgggaaact gaataggtta
-     1201 atcgagaaaa cgaacgagaa attccatcaa atcgaaaaag aattctcaga agtagaaggg
-     1261 agaattcagg acctcgagaa atatgttgaa gacactaaaa tagatctctg gtcttacaac
-     1321 gcggagcttc ttgttgccct ggagaaccaa catacaattg atcttactga ctcagaaatg
-     1381 aacaaactgt ttgaaaaaac aaggaagcaa ctgagggaaa atgctgagga catgggcaat
-     1441 ggttgcttca aaatatacca caaatgtgac aatgcctgca tagggtcaat cagaaatgga
-     1501 acttatgacc atgatgtata cagagacgaa gcattaaaca accggttcca gatcaaaggt
-     1561 gttgagctga agtcaggata caaagattgg atcctgtgga tttcctttgc catatcatgc
-     1621 tttttgcttt gtgttgtttt gctggggttc atcatgtggg cctgccaaaa aggcaacatt
-     1681 aggtgtaaca tttgcatttg a
+                     /product="hemagglutinin"
+                     /protein_id="AHX37629.1"
+                     /translation="MKTIIALSYILCLVFAQKLPGNDNSTATLCLGHHAVPNGTIVKT
+                     ITNDQIEVTNATELVQSSSTGEICDSPHQILDGKNCTLIDALLGDPQCDGFQNKKWDL
+                     FVERSKAYSNCYPYDVPDYASLRSLVASSGTLEFNNESFNWTGVTQNGTSSACIRRSK
+                     NSFFSRLNWLTHLNFKYPALNVTMPNNEQFDKLYIWGVLHPGTDKDQIFLYAQASGRI
+                     TVSTKRSQQTVSPNIGSRPRVRNIPSRISIYWTIVKPGDILLINSTGNLIAPRGYFKI
+                     RSGKSSIMRSDAPIGKCNSECITPNGSIPNDKPFQNVNRITYGACPRYVKQNTLKLAT
+                     GMRNVPEKQTRGIFGAIAGFIENGWEGMVDGWYGFRHQNSEGRGQAADLKSTQAAIDQ
+                     INGKLNRLIGKTNEKFHQIEKEFSEVEGRIQDLEKYVEDTKIDLWSYNAELLVALENQ
+                     HTIDLTDSEMNKLFEKTKKQLRENAEDMGNGCFKIYHKCDNACIGSIRNGTYDHDVYR
+                     DEALNNRFQIKGVELKSGYKDWILWISFAISCFLLCVALLGFIMWACQKGNIRCNICI
+                     "
+     sig_peptide     9..56
+                     /gene="HA"
+     mat_peptide     57..1043
+                     /gene="HA"
+                     /product="HA1"
+     mat_peptide     1044..1706
+                     /gene="HA"
+                     /product="HA2"
+ORIGIN      
+        1 tattaaccat gaagactatc attgctttga gctacattct atgtctggtt ttcgctcaaa
+       61 aacttcctgg aaatgacaac agcacggcaa cgctgtgcct tgggcaccat gcagtaccaa
+      121 acggaacgat agtgaaaaca atcacgaatg accaaattga agttactaat gctactgagc
+      181 tggttcagag ttcctcaaca ggtgaaatat gcgacagtcc tcatcagatc cttgatggaa
+      241 aaaactgcac actaatagat gctctattgg gagaccctca gtgtgatggc ttccaaaata
+      301 agaaatggga cctttttgtt gaacgcagca aagcctacag caactgttac ccttatgatg
+      361 tgccggatta tgcctccctt aggtcactag ttgcctcatc cggcacactg gagtttaaca
+      421 atgaaagctt caattggact ggagtcactc aaaacggaac aagctctgct tgcataagga
+      481 gatctaaaaa cagtttcttt agtagattga attggttgac ccacttaaac ttcaaatacc
+      541 cagcattgaa cgtgactatg ccaaacaatg aacaatttga caaattgtac atttgggggg
+      601 ttctccaccc gggtacggac aaagaccaaa tcttcctgta tgctcaagca tcaggaagaa
+      661 tcacagtctc taccaaaaga agccaacaaa ccgtaagccc gaatatcgga tctagaccca
+      721 gagtaaggaa tatccctagc agaataagca tctattggac aatagtaaaa ccgggagaca
+      781 tacttttgat taacagcaca gggaatctaa ttgctcctag gggttacttc aaaatacgaa
+      841 gtgggaaaag ctcaataatg agatcagatg cacccattgg caaatgcaat tctgaatgca
+      901 tcactccaaa tggaagcatt cccaatgaca aaccattcca aaatgtaaac aggatcacat
+      961 acggggcctg tcccagatat gttaagcaaa acactctgaa attggcaaca gggatgcgaa
+     1021 atgtaccaga gaaacaaact agaggcatat ttggcgcaat cgcgggtttc atagaaaatg
+     1081 gttgggaggg aatggtggat ggttggtacg gtttcaggca tcaaaattct gagggaagag
+     1141 gacaagcagc agatctcaaa agcactcaag cagcaatcga tcaaatcaat gggaagctga
+     1201 atagattgat cgggaaaacc aacgagaaat tccatcagat tgaaaaagaa ttctcagaag
+     1261 tcgaagggag aattcaggac cttgagaaat atgttgagga cactaaaata gatctctggt
+     1321 catacaacgc ggagcttctt gttgccctgg agaaccaaca tacaattgat ctaactgact
+     1381 cagaaatgaa caaactgttt gaaaaaacaa agaagcaact gagggaaaat gctgaggata
+     1441 tgggcaatgg ttgtttcaaa atataccaca aatgtgacaa tgcctgcata ggatcaatca
+     1501 gaaatggaac ttatgaccac gatgtataca gagatgaagc attaaacaac cggtttcaga
+     1561 tcaagggagt tgagctgaag tcagggtaca aagattggat cctatggatt tcctttgcca
+     1621 tatcatgttt tttgctttgt gttgctttgt tggggttcat catgtgggcc tgccaaaaag
+     1681 gcaacattag gtgcaacatt tgcatttgag tgcattaatt aaaaaca
 //

--- a/config/reference_h3n2_mp.gb
+++ b/config/reference_h3n2_mp.gb
@@ -1,84 +1,82 @@
-LOCUS       CY113678                 999 bp    DNA              VRL 04-APR-2012
-DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) matrix protein 2 (M2)
-            and matrix protein 1 (M1) genes, complete cds.
-ACCESSION   CY113678
-VERSION     CY113678.1
+LOCUS       KJ609209                1001 bp    cRNA    linear   VRL 25-MAR-2015
+DEFINITION  Influenza A virus (A/Perth/16/2009(H3N2)) segment 7 matrix protein
+            2 (M2) and matrix protein 1 (M1) genes, complete cds.
+ACCESSION   KJ609209
+VERSION     KJ609209.1
 KEYWORDS    .
-SOURCE      Influenza A virus (A/Beijing/32/1992(H3N2))
-  ORGANISM  Influenza A virus (A/Beijing/32/1992(H3N2))
+SOURCE      Influenza A virus (A/Perth/16/2009(H3N2))
+  ORGANISM  Influenza A virus (A/Perth/16/2009(H3N2))
             Viruses; ssRNA viruses; ssRNA negative-strand viruses;
             Orthomyxoviridae; Influenzavirus A.
-REFERENCE   1  (bases 1 to 999)
-  AUTHORS   Wentworth,D.E., Dugan,V., Halpin,R., Lin,X., Bera,J., Ghedin,E.,
-            Fedorova,N., Overton,L., Tsitrin,T., Stockwell,T., Amedeo,P.,
-            Bishop,B., Chen,H., Edworthy,P., Gupta,N., Katzel,D., Li,K.,
-            Schobel,S., Shrivastava,S., Thovarai,V., Wang,S., Westgeest,K.B.,
-            van Beek,R., Bestebroer,T.M., de Jong,J.C., Rimmelzwaan,G.F.,
-            Osterhaus,A.D.M.E., Fouchier,R.A.M., Bao,Y., Sanders,R.,
-            Dernovoy,D., Kiryutin,B., Lipman,D.J. and Tatusova,T.
-  TITLE     The NIAID Influenza Genome Sequencing Project
+REFERENCE   1  (bases 1 to 1001)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
+  TITLE     Innate immune response of BEAS-2B to influenza A (H3N2) viruses
   JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 999)
-  CONSRTM   The NIAID Influenza Genome Sequencing Consortium
+REFERENCE   2  (bases 1 to 1001)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
   TITLE     Direct Submission
-  JOURNAL   Submitted (04-APR-2012) on behalf of JCVI/Erasmus Medical
-            College/NCBI, National Center for Biotechnology Information, NIH,
-            Bethesda, MD 20894, USA
-COMMENT     This work was supported by the National Institute of Allergy and
-            Infectious Diseases (NIAID), Genome Sequencing Centers for
-            Infectious Diseases (GSCID) program.
+  JOURNAL   Submitted (14-MAR-2014) Office of Cyber Infrastructure and
+            Computational Biology, National Institute of Allergy and Infectious
+            Diseases, 31 Center Drive, Room 3B62, Bethesda, MD 20892, USA
+COMMENT     GenBank Accession Numbers KJ609203-KJ609210 represent sequences
+            from the 8 segments of Influenza A virus (A/Perth/16/2009(H3N2)).
+            
+            ##Assembly-Data-START##
+            Assembly Method       :: SOAPdenovo2-bin-LINUX-generic-r240
+            Coverage              :: 5075
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
-     source          1..999
-                     /bio_material="CEIRS#CIP047BE3292#"
-                     /collection_date="1992"
-                     /country="China: Beijing"
-                     /db_xref="taxon:380950"
-                     /host="Homo sapiens"
-                     /lab_host="xtMK3 MDCK1 passage(s)"
+     source          1..1001
+                     /organism="Influenza A virus (A/Perth/16/2009(H3N2))"
                      /mol_type="viral cRNA"
-                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
-                     /segment="7"
+                     /strain="A/Perth/16/2009"
                      /serotype="H3N2"
-                     /strain="A/Beijing/32/1992"
-     misc_feature    1..999
-                     /db_xref="IRD:NIGSP_CEIRS_CIP047_RFH3_00116.MP"
-     gene            11..992
+                     /host="Homo sapiens"
+                     /db_xref="taxon:654811"
+                     /segment="7"
+                     /country="Australia"
+                     /collection_date="07-Apr-2009"
+                     /note="passage details: E6, BEAS-2B 1"
+     misc_feature    1..1001
+                     /db_xref="IRD:IRD-Perth.7"
+     gene            15..996
                      /gene="M2"
-     CDS             join(11..36,725..992)
+     CDS             join(15..40,729..996)
+                     /gene="M2"
                      /codon_start=1
-                     /gene="M2"
                      /product="matrix protein 2"
-                     /protein_id="AFG99679.1"
-                     /translation="MSLLTEVETPIRNEWGCRCNDSSDPLVVAASIIGILHLILWILDR
-                     LFFKCIYRLFKHGLKRGPSTEGVPESMREEYRKEQQNAVDADDSHFVSIELE"
-     gene            11..769
+                     /protein_id="AHX37633.1"
+                     /translation="MSLLTEVETPIRNEWGCRCNDSSDPLVVAANIIGILHLILWILD
+                     RLFFKCVYRLFKHGLKRGPSTEGVPESMREEYRKEQQNAVDADDSHFVSIELE"
+     gene            15..773
                      /gene="M1"
-     CDS             11..769
+     CDS             15..773
+                     /gene="M1"
                      /codon_start=1
-                     /gene="M1"
                      /product="matrix protein 1"
-                     /protein_id="AFG99678.1"
-                     /translation="MSLLTEVETYVLSIVPSGPLKAEIAQRLEDVFAGKNTDLEALMEW
-                     LKTRPILSPLTKGILGFVFTLTVPSERGLQRRRFVQNALNGNGDPNNMDRAVKLYRKLK
-                     REITFHGAKEIALSYSAGALASCMGLIYNRMGAVTTEVAFGLVCATCEQIADSQHRSHR
-                     QMVATTNPLIRHENRMVLASTTAKAMEQMAGSSEQAAEAMEIASQARQMVQAMRAIGTH
-                     PSSSAGLKDDLLENLQTYQKRMGVQMQRFK"
-ORIGIN
-        1 atattgaaag atgagccttc taaccgaggt cgaaacgtat gttctctcta tcgttccatc
-       61 aggccccctc aaagccgaaa tcgcgcagag acttgaagat gtctttgctg ggaaaaacac
-      121 agatcttgag gctctcatgg aatggctaaa gacaagacca atcctgtcac ctctgactaa
-      181 ggggattttg gggtttgtgt tcacgctcac cgtgcccagt gagcgaggac tgcagcgtag
-      241 acgctttgtc caaaatgccc tcaatgggaa tggggatcca aataacatgg acagagcagt
-      301 taaactatat agaaaactta agagggagat tacattccat ggggccaaag aaatagcact
-      361 cagttattct gctggtgcac ttgccagttg catgggcctc atatacaaca gaatgggggc
-      421 tgtaaccact gaagtggcct ttggcctggt atgtgcaaca tgtgaacaga ttgctgactc
-      481 ccagcacagg tctcataggc aaatggtggc aacaaccaat ccattaataa ggcatgagaa
-      541 cagaatggtt ttggccagca ctacagctaa ggctatggag caaatggctg gatcaagtga
-      601 gcaggcagcg gaggccatgg aaattgctag tcaggccagg caaatggtgc aggcaatgag
-      661 agccattggg actcatccta gctccagtgc tggtctaaaa gatgatcttc ttgaaaattt
-      721 gcagacctat cagaaacgaa tgggggtgca gatgcaacga ttcaagtgac ccgcttgttg
-      781 ttgctgcgag tatcattggg atattgcact tgatattgtg gattcttgat cgtctttttt
-      841 tcaaatgcat ctatcgactc ttcaaacacg gcctgaaaag agggccttct acggaaggag
-      901 tacctgagtc tatgagggaa gaatatcgaa aggaacagca gaatgctgtg gatgctgacg
-      961 acagtcattt tgtcagcata gagctggagt aaaaaacta
+                     /protein_id="AHX37632.1"
+                     /translation="MSLLTEVETYVLSIVPSGPLKAEIAQRLEDVFAGKNTDLEALME
+                     WLKTRPILSPLTKGILGFVFTLTVPSERGLQRRRFVQNALNGNGDPNNMDKAVKLYRK
+                     LKREITFHGAKEIALSYSAGALASCMGLIYNRMGAVTTEVAFGLVCATCEQIADSQHR
+                     SHRQMVATTNPLIKHENRMVLASTTAKAMEQMAGSSEQAAEAMEIASQARQMVQAMRA
+                     IGTHPSSSTGLRDDLLENLQTYQKRMGVQMQRFK"
+ORIGIN      
+        1 gtagatgttg aaagatgagc cttctaaccg aggtcgaaac gtatgttctc tctatcgttc
+       61 catcaggccc cctcaaagcc gagatcgcgc agagacttga agatgtcttt gctgggaaaa
+      121 acacagatct tgaggctctc atggaatggc taaagacaag accaattctg tcacctctga
+      181 ctaaggggat tttggggttt gtgttcacgc tcaccgtgcc cagtgagcga ggactgcagc
+      241 gtagacgctt tgtccaaaat gccctcaatg ggaatggaga cccaaataac atggacaaag
+      301 cagttaaact gtataggaaa cttaagagag agataacgtt ccatggggcc aaagaaatag
+      361 ctctcagtta ttccgctggt gcacttgcca gttgcatggg cctcatatac aataggatgg
+      421 gggctgtaac cactgaagtg gcatttggcc tggtatgtgc aacatgtgag cagattgctg
+      481 actcccagca caggtctcat aggcagatgg tggcaacaac caatccatta ataaaacatg
+      541 agaacagaat ggttttggcc agcactacag ctaaggctat ggagcaaatg gctggatcaa
+      601 gtgaacaggc agcggaggcc atggagattg ctagtcaggc caggcagatg gtgcaggcaa
+      661 tgagagccat tgggactcat cctagttcca gtactggttt aagagatgat cttcttgaaa
+      721 atttgcagac ctatcagaaa cgaatggggg tgcagatgca acgattcaag tgacccgctt
+      781 gttgttgccg cgaatatcat tgggatcttg cacttgatat tgtggattct tgatcgtctt
+      841 tttttcaaat gcgtctatcg actcttcaaa cacggcctta aaagaggccc ttctacggaa
+      901 ggagtacctg agtctatgag ggaagaatat cgaaaggaac agcagaatgc tgtggatgct
+      961 gacgacagtc attttgtcag catagagttg gagtaaaaaa c
 //

--- a/config/reference_h3n2_na.gb
+++ b/config/reference_h3n2_na.gb
@@ -1,86 +1,91 @@
-LOCUS       CY113679                1436 bp    DNA              VRL 04-APR-2012
-DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) neuraminidase (NA) gene,
-            complete cds.
-ACCESSION   CY113679
-VERSION     CY113679.1
+LOCUS       KJ609208                1441 bp    cRNA    linear   VRL 25-MAR-2015
+DEFINITION  Influenza A virus (A/Perth/16/2009(H3N2)) segment 6 neuraminidase
+            (NA) gene, complete cds.
+ACCESSION   KJ609208
+VERSION     KJ609208.1
 KEYWORDS    .
-SOURCE      Influenza A virus (A/Beijing/32/1992(H3N2))
-  ORGANISM  Influenza A virus (A/Beijing/32/1992(H3N2))
+SOURCE      Influenza A virus (A/Perth/16/2009(H3N2))
+  ORGANISM  Influenza A virus (A/Perth/16/2009(H3N2))
             Viruses; ssRNA viruses; ssRNA negative-strand viruses;
             Orthomyxoviridae; Influenzavirus A.
-REFERENCE   1  (bases 1 to 1436)
-  AUTHORS   Wentworth,D.E., Dugan,V., Halpin,R., Lin,X., Bera,J., Ghedin,E.,
-            Fedorova,N., Overton,L., Tsitrin,T., Stockwell,T., Amedeo,P.,
-            Bishop,B., Chen,H., Edworthy,P., Gupta,N., Katzel,D., Li,K.,
-            Schobel,S., Shrivastava,S., Thovarai,V., Wang,S., Westgeest,K.B.,
-            van Beek,R., Bestebroer,T.M., de Jong,J.C., Rimmelzwaan,G.F.,
-            Osterhaus,A.D.M.E., Fouchier,R.A.M., Bao,Y., Sanders,R.,
-            Dernovoy,D., Kiryutin,B., Lipman,D.J. and Tatusova,T.
-  TITLE     The NIAID Influenza Genome Sequencing Project
+REFERENCE   1  (bases 1 to 1441)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
+  TITLE     Innate immune response of BEAS-2B to influenza A (H3N2) viruses
   JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 1436)
-  CONSRTM   The NIAID Influenza Genome Sequencing Consortium
+REFERENCE   2  (bases 1 to 1441)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
   TITLE     Direct Submission
-  JOURNAL   Submitted (04-APR-2012) on behalf of JCVI/Erasmus Medical
-            College/NCBI, National Center for Biotechnology Information, NIH,
-            Bethesda, MD 20894, USA
-COMMENT     This work was supported by the National Institute of Allergy and
-            Infectious Diseases (NIAID), Genome Sequencing Centers for
-            Infectious Diseases (GSCID) program.
+  JOURNAL   Submitted (14-MAR-2014) Office of Cyber Infrastructure and
+            Computational Biology, National Institute of Allergy and Infectious
+            Diseases, 31 Center Drive, Room 3B62, Bethesda, MD 20892, USA
+COMMENT     GenBank Accession Numbers KJ609203-KJ609210 represent sequences
+            from the 8 segments of Influenza A virus (A/Perth/16/2009(H3N2)).
+            
+            ##Assembly-Data-START##
+            Assembly Method       :: SOAPdenovo2-bin-LINUX-generic-r240
+            Coverage              :: 2712
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
-     source          1..1436
-                     /bio_material="CEIRS#CIP047BE3292#"
-                     /collection_date="1992"
-                     /country="China: Beijing"
-                     /db_xref="taxon:380950"
-                     /host="Homo sapiens"
-                     /lab_host="xtMK3 MDCK1 passage(s)"
+     source          1..1441
+                     /organism="Influenza A virus (A/Perth/16/2009(H3N2))"
                      /mol_type="viral cRNA"
-                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
-                     /segment="6"
+                     /strain="A/Perth/16/2009"
                      /serotype="H3N2"
-                     /strain="A/Beijing/32/1992"
-     misc_feature    1..1436
-                     /db_xref="IRD:NIGSP_CEIRS_CIP047_RFH3_00116.NA"
-     gene            4..1413
+                     /host="Homo sapiens"
+                     /db_xref="taxon:654811"
+                     /segment="6"
+                     /country="Australia"
+                     /collection_date="07-Apr-2009"
+                     /note="passage details: E6, BEAS-2B 1"
+     gene            1..1441
                      /gene="NA"
-     CDS             4..1410
+     mRNA            1..1441
+                     /gene="NA"
+                     /product="NA1"
+     mRNA            join(1..1130,1253..1441)
+                     /gene="NA"
+                     /product="NA8"
+     misc_feature    1..1441
+                     /db_xref="IRD:IRD-Perth.6"
+     CDS             13..1422
+                     /gene="NA"
                      /codon_start=1
-                     /gene="NA"
                      /product="neuraminidase"
-                     /protein_id="AFG99680.1"
-                     /translation="MNPNQKIITIGSVSLTIATICFLMQIAILVTTVTLHFKQYECSSP
-                     PNNQVILCQPTIIERNITEIVYLTNTTIEKEICPKLVEYRNWSKPQCKITGFAPFSKDN
-                     SIRLSAGGDIWVTREPYVSCDPSKCYQFALGQGTTLNNRHSNDTVHDRTPYRTLLMNEL
-                     GVPFHLGTKQVCIAWSSSSCHDGKAWLHVCVTGHDENATASFIYDGRLVDSIGSWSKNI
-                     LRTQESECVCINGTCTVVMTDGSASERADTKILFIEEGKVVHISPLSGSAQHVEECSCY
-                     PRYPGVRCVCRDNWKGSNRPIVDINVKDYSIVSSYVCSGLVGDTPRKNDSSSSSYCRNP
-                     NNEKGSHGVKGWAFDDGNDVWMGRTISEELRSGYETFKVIGGWSTPNSKLQINRQVIVD
-                     SGNRSGYSGIFSVEGKSCINRCFYVELIRGRKQETKVWWTSNSIVVFCGTSGTYGTGSW
-                     PDGADINLMPI"
-ORIGIN
-        1 aagatgaatc caaatcaaaa gataataaca attggctctg tttctctcac tattgccaca
-       61 atatgcttcc ttatgcaaat tgccatcctg gtaactactg taacattgca tttcaagcaa
-      121 tatgagtgca gctccccccc aaacaaccaa gtaattctat gtcaaccaac aataatagaa
-      181 agaaacataa cagagatagt gtatttgact aacaccacca tagagaaaga gatatgcccc
-      241 aaactagtag aatacagaaa ttggtcaaag ccgcaatgta aaattacagg atttgcacct
-      301 ttttctaagg acaattcaat tcggctttcc gctggtggag acatttgggt gacaagagaa
-      361 ccttatgtgt catgcgatcc tagcaaatgt tatcaatttg cacttggaca gggaaccaca
-      421 ctaaacaaca ggcattcaaa tgacacagta catgatagga ccccttatcg aaccctcttg
-      481 atgaatgagt tgggtgttcc atttcatttg ggaaccaagc aagtgtgcat agcatggtcc
-      541 agctcaagtt gtcacgatgg aaaagcatgg ctgcatgttt gtgtcactgg gcatgatgaa
-      601 aatgcaactg ctagcttcat ttacgatggg aggcttgtag atagtattgg ttcatggtcc
-      661 aaaaatatcc tcaggaccca ggagtcggaa tgcgtttgta tcaatgggac ttgtacagta
-      721 gtaatgactg atggaagtgc ttcagaaaga gctgatacta aaatactatt cattgaagag
-      781 gggaaagtcg ttcatattag cccattgtca ggaagtgctc agcatgtaga ggagtgctcc
-      841 tgttatcctc gatatcctgg tgtcagatgt gtctgcagag acaactggaa aggctccaat
-      901 aggcccatcg tagatataaa tgtgaaagat tatagcattg tttccagtta tgtgtgctca
-      961 gggcttgttg gagacacacc cagaaaaaac gacagctcca gcagtagcta ttgccggaat
-     1021 cctaacaatg agaaagggag tcatggagtg aaaggctggg cctttgacga tggaaatgac
-     1081 gtgtggatgg gaagaacgat cagcgaggag ttacgctcag gttatgaaac cttcaaagtc
-     1141 attggaggtt ggtccacacc taattccaaa ttgcagataa ataggcaagt catagttgac
-     1201 agcggtaata ggtccggtta ttctggtatt ttctctgttg aaggcaaaag ctgcatcaat
-     1261 cggtgctttt atgtggagtt gataagggga aggaaacagg aaactaaagt ctggtggacc
-     1321 tcaaacagta ttgttgtgtt ttgtggcacc tcaggtacat atggaacagg ctcatggcct
-     1381 gatggggcgg acatcaatct catgcctata taagctttcg caattttaga aaaaac
+                     /protein_id="AHX37631.1"
+                     /translation="MNPNQKIITIGSVSLTISTICFFMQIAILITTVTLHFKQYEFNS
+                     PPNNQVMLCEPTIIERNITEIVYLTNTTIEKEICPKLAEYRNWSKPQCDITGFAPFSK
+                     DNSIRLSAGGDIWVTREPYVSCDPDKCYQFALGQGTTLNNVHSNNTVRDRTPYRTLLM
+                     NELGVPFHLGTKQVCIAWSSSSCHDGKAWLHVCITGDDKNATASFIYNGRLVDSVVSW
+                     SKEILRTQESECVCINGTCTVVMTDGSASGKADTKILFIEEGKIVHTSTLSGSAQHVE
+                     ECSCYPRYPGVRCVCRDNWKGSNRPIVDINIKDHSIVSSYVCSGLVGDTPRKNDSSSS
+                     SHCLDPNNEEGGHGVKGWAFDDGNDVWMGRTISEKSRLGYETFKVIEGWSNPKSKLQI
+                     NRQVIVDRGNRSGYSGIFSVEGKSCINRCFYVELIRGRKEETEVLWTSNSIVVFCGTS
+                     GTYGTGSWPDGADINLMPI"
+ORIGIN      
+        1 gcaggagtaa agatgaatcc aaatcaaaag ataataacta ttggctctgt ttctctcacc
+       61 atttccacaa tatgcttctt catgcaaatt gccatcttga taactactgt aacattgcat
+      121 ttcaagcaat atgaattcaa ctccccccca aacaaccaag tgatgctgtg tgaaccaaca
+      181 ataatagaaa gaaacataac agagatagtg tatctgacca acaccaccat agagaaggaa
+      241 atatgcccca aactagcaga atacagaaat tggtcaaagc cgcaatgtga cattacaggg
+      301 tttgcacctt tttctaagga caattcgatt aggctttccg ctggtgggga catctgggtg
+      361 acaagagaac cttatgtgtc atgcgatcct gacaagtgtt atcaatttgc ccttggacag
+      421 ggaacaacac taaacaacgt acattcaaat aacacagtac gtgataggac cccttatcgg
+      481 accctattga tgaatgagtt aggtgttcct tttcatctgg ggaccaagca agtgtgcata
+      541 gcatggtcca gctcaagttg tcacgatgga aaagcatggc tgcatgtttg tataacgggg
+      601 gatgataaaa atgcaactgc tagcttcatt tacaatggga ggcttgtaga tagtgttgtt
+      661 tcatggtcca aagaaatcct caggacccag gagtcagaat gcgtttgtat caatggaact
+      721 tgtacagtag taatgactga tgggagtgct tcaggaaaag ctgatactaa aatactattc
+      781 attgaggagg ggaaaatcgt tcatactagc acattgtcag gaagtgctca gcatgtcgag
+      841 gagtgctcct gctatcctcg atatcctggt gtcagatgtg tctgcagaga caactggaaa
+      901 ggatccaata ggcccatcgt agatataaac ataaaggatc atagcattgt ttccagttat
+      961 gtgtgttcag gacttgttgg agacacaccc agaaaaaacg acagctccag cagtagccat
+     1021 tgtttggatc ctaacaatga ggaaggtggt catggggtga aaggctgggc ctttgatgat
+     1081 ggaaatgacg tgtggatggg aagaacgatc agcgagaagt cacgcttagg gtatgaaacc
+     1141 ttcaaagtca ttgaaggctg gtccaaccct aagtccaaat tgcagataaa taggcaagtc
+     1201 atagttgaca gaggtaatag gtccggttat tctggtattt tctctgttga aggcaaaagc
+     1261 tgcatcaatc ggtgctttta tgtggagttg ataaggggaa gaaaagagga aactgaagtc
+     1321 ttgtggacct caaacagtat tgttgtgttt tgtggcacct caggtacata tggaacaggc
+     1381 tcatggcctg atggggcgga catcaatctc atgcctatat aagcttccgc aattttagaa
+     1441 a
 //

--- a/config/reference_h3n2_np.gb
+++ b/config/reference_h3n2_np.gb
@@ -1,88 +1,86 @@
-LOCUS       CY113680                1537 bp    DNA              VRL 04-APR-2012
-DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) nucleocapsid protein
-            (NP) gene, complete cds.
-ACCESSION   CY113680
-VERSION     CY113680.1
+LOCUS       KJ609207                1530 bp    cRNA    linear   VRL 25-MAR-2015
+DEFINITION  Influenza A virus (A/Perth/16/2009(H3N2)) segment 5 nucleocapsid
+            protein (NP) gene, complete cds.
+ACCESSION   KJ609207
+VERSION     KJ609207.1
 KEYWORDS    .
-SOURCE      Influenza A virus (A/Beijing/32/1992(H3N2))
-  ORGANISM  Influenza A virus (A/Beijing/32/1992(H3N2))
+SOURCE      Influenza A virus (A/Perth/16/2009(H3N2))
+  ORGANISM  Influenza A virus (A/Perth/16/2009(H3N2))
             Viruses; ssRNA viruses; ssRNA negative-strand viruses;
             Orthomyxoviridae; Influenzavirus A.
-REFERENCE   1  (bases 1 to 1537)
-  AUTHORS   Wentworth,D.E., Dugan,V., Halpin,R., Lin,X., Bera,J., Ghedin,E.,
-            Fedorova,N., Overton,L., Tsitrin,T., Stockwell,T., Amedeo,P.,
-            Bishop,B., Chen,H., Edworthy,P., Gupta,N., Katzel,D., Li,K.,
-            Schobel,S., Shrivastava,S., Thovarai,V., Wang,S., Westgeest,K.B.,
-            van Beek,R., Bestebroer,T.M., de Jong,J.C., Rimmelzwaan,G.F.,
-            Osterhaus,A.D.M.E., Fouchier,R.A.M., Bao,Y., Sanders,R.,
-            Dernovoy,D., Kiryutin,B., Lipman,D.J. and Tatusova,T.
-  TITLE     The NIAID Influenza Genome Sequencing Project
+REFERENCE   1  (bases 1 to 1530)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
+  TITLE     Innate immune response of BEAS-2B to influenza A (H3N2) viruses
   JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 1537)
-  CONSRTM   The NIAID Influenza Genome Sequencing Consortium
+REFERENCE   2  (bases 1 to 1530)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
   TITLE     Direct Submission
-  JOURNAL   Submitted (04-APR-2012) on behalf of JCVI/Erasmus Medical
-            College/NCBI, National Center for Biotechnology Information, NIH,
-            Bethesda, MD 20894, USA
-COMMENT     This work was supported by the National Institute of Allergy and
-            Infectious Diseases (NIAID), Genome Sequencing Centers for
-            Infectious Diseases (GSCID) program.
+  JOURNAL   Submitted (14-MAR-2014) Office of Cyber Infrastructure and
+            Computational Biology, National Institute of Allergy and Infectious
+            Diseases, 31 Center Drive, Room 3B62, Bethesda, MD 20892, USA
+COMMENT     GenBank Accession Numbers KJ609203-KJ609210 represent sequences
+            from the 8 segments of Influenza A virus (A/Perth/16/2009(H3N2)).
+            
+            ##Assembly-Data-START##
+            Assembly Method       :: SOAPdenovo2-bin-LINUX-generic-r240
+            Coverage              :: 2284
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
-     source          1..1537
-                     /bio_material="CEIRS#CIP047BE3292#"
-                     /collection_date="1992"
-                     /country="China: Beijing"
-                     /db_xref="taxon:380950"
-                     /host="Homo sapiens"
-                     /lab_host="xtMK3 MDCK1 passage(s)"
+     source          1..1530
+                     /organism="Influenza A virus (A/Perth/16/2009(H3N2))"
                      /mol_type="viral cRNA"
-                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
-                     /segment="5"
+                     /strain="A/Perth/16/2009"
                      /serotype="H3N2"
-                     /strain="A/Beijing/32/1992"
-     misc_feature    1..1537
-                     /db_xref="IRD:NIGSP_CEIRS_CIP047_RFH3_00116.NP"
-     gene            31..1527
+                     /host="Homo sapiens"
+                     /db_xref="taxon:654811"
+                     /segment="5"
+                     /country="Australia"
+                     /collection_date="07-Apr-2009"
+                     /note="passage details: E6, BEAS-2B 1"
+     misc_feature    1..1530
+                     /db_xref="IRD:IRD-Perth.5"
+     gene            24..1520
                      /gene="NP"
-     CDS             31..1527
+     CDS             24..1520
+                     /gene="NP"
                      /codon_start=1
-                     /gene="NP"
                      /product="nucleocapsid protein"
-                     /protein_id="AFG99681.1"
-                     /translation="MASQGTKRSYEQMETDGERQNATEIRASVGKMIDGIGRFYIQMCT
-                     ELKLSDYEGRLIQNSLTIERMVLSAFDERRNRYLEEHPSAGKDPKKTGGPIYKRVDGRW
-                     MRELVLYDKEEIRRIWRQANNGDDATAGLTHMMIWHSNLNDTTYQRTRALVRTGMDPRM
-                     CSLMQGSTLPRRSGAAGAAVKGIGTMVMELIRMIKRGINDRNFWRGENGRKTRSAYERM
-                     CNILKGKFQTAAQRAMMDQVRESRNPGNAEIEDLIFSARSALILRGSVAHKSCLPACVY
-                     GPAVSSGYDFEKEGYSLVGIDPFKLLQNSQVYSLIRPNENPAHKSQLVWMACHSAAFED
-                     LRLLSFIRGTKVSPRGKLSTRGVQIASNENMDNMESSTLELRSRYWAIRTRSGGNTNQQ
-                     RASAGQISVQPTFSVQRNLPFEKSTVMAAFTGNTEGRTSDMRAEIIRMMEGAKPEEVSF
-                     RGRGVFELSDEKATNPIVPSFDMSNEGSYFFGDNAEEYDN"
-ORIGIN
-        1 aataatcact cactgagtga catcaaaatc atggcgtccc aaggcaccaa acggtcttat
-       61 gaacagatgg aaactgatgg ggaacgccag aatgcaactg agattagggc atccgtcggg
-      121 aagatgattg atggaattgg gcgattctac atccaaatgt gcactgaact taaactcagt
-      181 gattatgaag ggcggttgat ccagaacagc ttgacaatag agagaatggt gctctctgct
-      241 tttgatgaga gaaggaatag atatctggaa gaacacccca gcgcggggaa agatcctaag
-      301 aaaactggag ggcccatata caagagagta gatggaagat ggatgaggga actcgtcctt
-      361 tatgacaaag aagaaataag gcgaatctgg cgccaagcca acaatggtga tgatgcgaca
-      421 gctggtctaa ctcacatgat gatctggcat tccaatttga atgatacaac ataccagagg
-      481 acaagagctc ttgttcgcac cgggatggac cccaggatgt gctctctgat gcagggttcg
-      541 actctcccta gaaggtccgg agctgcaggc gctgcagtca aaggaatcgg gacaatggtg
-      601 atggagctta tcagaatgat caaacggggg atcaacgatc gaaatttctg gagaggtgag
-      661 aatgggcgga aaacaaggag tgcttatgag agaatgtgca acattcttaa aggaaaattt
-      721 caaacagctg cacaaagagc aatgatggat caagtgagag aaagccggaa cccaggaaat
-      781 gctgagatcg aagatctcat attttcggca agatctgcac taatattgag agggtcagtt
-      841 gctcacaaat cttgcctacc tgcctgtgtg tatggacctg cagtatccag tgggtacgac
-      901 ttcgaaaaag agggatattc cttagtggga atagaccctt tcaaactact tcaaaatagt
-      961 caagtataca gcctaatcag accgaacgag aatccagcac acaagagtca gctggtgtgg
-     1021 atggcatgcc attctgctgc atttgaagat ttaagattgt taagcttcat cagagggacc
-     1081 aaagtatctc cgcgggggaa actttcaact agaggagtac aaattgcttc aaatgagaac
-     1141 atggataata tggaatcaag tactcttgaa ctgagaagca ggtactgggc aataaggacc
-     1201 aggagtggag gaaacactaa tcaacagagg gcctccgcag gccaaatcag tgtgcaacct
-     1261 acattttctg tacaaagaaa cctcccattt gaaaagtcaa ccgtcatggc agcattcact
-     1321 ggaaatacgg agggaagaac ctcagacatg agggcagaaa tcataaggat gatggaaggt
-     1381 gcaaaaccag aagaagtgtc cttccgtggg cggggagttt tcgagctctc agacgaaaag
-     1441 gcaacgaacc cgatcgtgcc ctcttttgac atgagtaatg aaggatctta tttcttcgga
-     1501 gacaatgcag aagagtacga caattaagaa aaaaata
+                     /protein_id="AHX37630.1"
+                     /translation="MASQGTKRSYEQMETDGDRQNATEIRASVGKMIDGIGRFYIQMC
+                     TELKLSDHEGRLIQNSLTIEKMVLSAFDERRNKYLEEHPSAGKDPKKTGGPIYRRVDG
+                     KWMRELVLYDKEEIRRIWRQANNGEDATSGLTHIMIWHSNLNDATYQRTRALVRTGMD
+                     PRMCSLMQGSTLPRRSGAAGAAVKGIGTMVMELIRMVKRGINDRNFWRGENGRKTRSA
+                     YERMCNILKGKFQTAAQRAMVDQVRESRNPGNAEIEDLIFLARSALILRGSVAHKSCL
+                     PACAYGPAVSSGYDFEKEGYSLVGIDPFKLLQNSQIYSLIRPNENPAHKSQLVWMACH
+                     SAAFEDLRLLSFIRGTKVSPRGKLSTRGVQIASNENMDNMGSSTLELRSGYWAIRTRS
+                     GGNTNQQRASAGQTSVQPTFSVQRNLPFEKSTIMAAFTGNTEGRTSDMRAEIIRMMES
+                     AKPEEVSFRGRGVFELSDEKATNPIVPSFDMSNEGSYFFGDNAEEYDN"
+ORIGIN      
+        1 actcactgag tgacatcaaa atcatggcgt cccaaggcac caaacggtct tatgaacaga
+       61 tggaaactga tggggatcgc cagaatgcaa ctgagattag ggcatccgta gggaagatga
+      121 ttgatggaat tgggagattc tacatccaaa tgtgcactga acttaaactc agtgatcatg
+      181 aagggcggtt gatccagaac agcttgacaa tagagaaaat ggtactctct gcttttgatg
+      241 aaagaaggaa taaatacctg gaagaacacc ccagcgcggg gaaagatccc aagaaaactg
+      301 ggggacccat atacaggaga gtagatggaa aatggatgag ggaactcgtc ctttatgaca
+      361 aagaagaaat aaggcgaatc tggcgccaag ccaacaatgg tgaggatgct acatctggtc
+      421 taactcacat aatgatttgg cattccaatt tgaatgatgc aacataccag aggacaagag
+      481 ctcttgttcg aactggaatg gatcccagaa tgtgctctct gatgcagggc tcgactctcc
+      541 ctagaaggtc cggagctgca ggtgctgcag tcaaaggaat cgggacaatg gtgatggaac
+      601 taatcagaat ggtcaaacgg gggatcaacg atcgaaattt ttggagaggt gagaatggac
+      661 ggaaaacaag aagtgcttat gagagaatgt gcaacattct taaaggaaaa tttcaaacag
+      721 ctgcacaaag agcaatggtg gatcaagtga gagaaagtcg gaacccagga aacgctgaga
+      781 tcgaagatct catattttta gcaagatctg cattgatatt gagaggatca gttgctcaca
+      841 aatcttgcct acctgcttgt gcgtatggac ctgcagtatc cagtgggtac gacttcgaaa
+      901 aagagggata ttccttggtg ggaatagacc ctttcaaact acttcaaaat agccaaatat
+      961 acagcttaat cagacctaac gagaatccag cacacaagag tcagctggtg tggatggcat
+     1021 gccattctgc tgcatttgaa gatttaagat tgttaagctt catcagaggg acaaaagtat
+     1081 ctcctcgggg gaaactgtca actagaggag tacaaattgc ttcaaatgag aacatggata
+     1141 atatgggatc gagcactctt gaactgagaa gcgggtactg ggccataagg accaggagtg
+     1201 gaggaaacac taatcaacag agggcctccg caggtcaaac cagtgtgcaa cctacgtttt
+     1261 ctgtacaaag aaacctccca tttgaaaagt caaccatcat ggcagcattc actggaaata
+     1321 cggagggaag aacttcagac atgagggcag aaatcataag aatgatggaa agtgcaaaac
+     1381 cagaagaagt gtcattccgg gggaggggag tcttcgagct ctcagacgag aaggcaacga
+     1441 acccgatcgt gccctctttt gatatgagta atgaaggatc ttatttcttc ggagacaatg
+     1501 cagaagagta tgacaattaa ggaaaaaata
 //

--- a/config/reference_h3n2_ns.gb
+++ b/config/reference_h3n2_ns.gb
@@ -1,86 +1,85 @@
-LOCUS       CY113681                 864 bp    DNA              VRL 04-APR-2012
-DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) nuclear export protein
-            (NEP) and nonstructural protein 1 (NS1) genes, complete cds.
-ACCESSION   CY113681
-VERSION     CY113681.1
+LOCUS       KJ609210                 866 bp    cRNA    linear   VRL 25-MAR-2015
+DEFINITION  Influenza A virus (A/Perth/16/2009(H3N2)) segment 8 nuclear export
+            protein (NEP) and nonstructural protein 1 (NS1) genes, complete
+            cds.
+ACCESSION   KJ609210
+VERSION     KJ609210.1
 KEYWORDS    .
-SOURCE      Influenza A virus (A/Beijing/32/1992(H3N2))
-  ORGANISM  Influenza A virus (A/Beijing/32/1992(H3N2))
+SOURCE      Influenza A virus (A/Perth/16/2009(H3N2))
+  ORGANISM  Influenza A virus (A/Perth/16/2009(H3N2))
             Viruses; ssRNA viruses; ssRNA negative-strand viruses;
             Orthomyxoviridae; Influenzavirus A.
-REFERENCE   1  (bases 1 to 864)
-  AUTHORS   Wentworth,D.E., Dugan,V., Halpin,R., Lin,X., Bera,J., Ghedin,E.,
-            Fedorova,N., Overton,L., Tsitrin,T., Stockwell,T., Amedeo,P.,
-            Bishop,B., Chen,H., Edworthy,P., Gupta,N., Katzel,D., Li,K.,
-            Schobel,S., Shrivastava,S., Thovarai,V., Wang,S., Westgeest,K.B.,
-            van Beek,R., Bestebroer,T.M., de Jong,J.C., Rimmelzwaan,G.F.,
-            Osterhaus,A.D.M.E., Fouchier,R.A.M., Bao,Y., Sanders,R.,
-            Dernovoy,D., Kiryutin,B., Lipman,D.J. and Tatusova,T.
-  TITLE     The NIAID Influenza Genome Sequencing Project
+REFERENCE   1  (bases 1 to 866)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
+  TITLE     Innate immune response of BEAS-2B to influenza A (H3N2) viruses
   JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 864)
-  CONSRTM   The NIAID Influenza Genome Sequencing Consortium
+REFERENCE   2  (bases 1 to 866)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
   TITLE     Direct Submission
-  JOURNAL   Submitted (04-APR-2012) on behalf of JCVI/Erasmus Medical
-            College/NCBI, National Center for Biotechnology Information, NIH,
-            Bethesda, MD 20894, USA
-COMMENT     This work was supported by the National Institute of Allergy and
-            Infectious Diseases (NIAID), Genome Sequencing Centers for
-            Infectious Diseases (GSCID) program.
+  JOURNAL   Submitted (14-MAR-2014) Office of Cyber Infrastructure and
+            Computational Biology, National Institute of Allergy and Infectious
+            Diseases, 31 Center Drive, Room 3B62, Bethesda, MD 20892, USA
+COMMENT     GenBank Accession Numbers KJ609203-KJ609210 represent sequences
+            from the 8 segments of Influenza A virus (A/Perth/16/2009(H3N2)).
+            
+            ##Assembly-Data-START##
+            Assembly Method       :: SOAPdenovo2-bin-LINUX-generic-r240
+            Coverage              :: 3983
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
-     source          1..864
-                     /bio_material="CEIRS#CIP047BE3292#"
-                     /collection_date="1992"
-                     /country="China: Beijing"
-                     /db_xref="taxon:380950"
-                     /host="Homo sapiens"
-                     /lab_host="xtMK3 MDCK1 passage(s)"
+     source          1..866
+                     /organism="Influenza A virus (A/Perth/16/2009(H3N2))"
                      /mol_type="viral cRNA"
-                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
-                     /segment="8"
+                     /strain="A/Perth/16/2009"
                      /serotype="H3N2"
-                     /strain="A/Beijing/32/1992"
-     misc_feature    1..864
-                     /db_xref="IRD:NIGSP_CEIRS_CIP047_RFH3_00116.NS"
-     gene            12..849
+                     /host="Homo sapiens"
+                     /db_xref="taxon:654811"
+                     /segment="8"
+                     /country="Australia"
+                     /collection_date="07-Apr-2009"
+                     /note="passage details: E6, BEAS-2B 1"
+     misc_feature    1..866
+                     /db_xref="IRD:IRD-Perth.8"
+     gene            17..854
                      /gene="NEP"
                      /gene_synonym="NS2"
-     CDS             join(12..41,514..849)
-                     /codon_start=1
+     CDS             join(17..46,519..854)
                      /gene="NEP"
                      /gene_synonym="NS2"
                      /note="nonstructural protein 2"
-                     /product="nuclear export protein"
-                     /protein_id="AFG99683.1"
-                     /translation="MDSNTVSSFQDILLRMSKMQLGSSSEDLNGMITQFESLKIYRDSL
-                     GEAVMRMGDLHLLQNRNGKWREQLGQKFEEIRWLIEEVRHRLKTTENSFEQITFMQALQ
-                     LLFEVEQEIRTFSFQLI"
-     gene            12..704
-                     /gene="NS1"
-     CDS             12..704
                      /codon_start=1
+                     /product="nuclear export protein"
+                     /protein_id="AHX37635.1"
+                     /translation="MDSNTVSSFQDILLRMSKMQLGSSSEDLNGMITQFESLKIYRDS
+                     LGEAVMRMGDLHLLQNRNGKWREQLGQKFEEIRWLIEEVRHRLKTTENSFEQITFMQA
+                     LQLLFEVEQEIRTFSFQLI"
+     gene            17..709
                      /gene="NS1"
+     CDS             17..709
+                     /gene="NS1"
+                     /codon_start=1
                      /product="nonstructural protein 1"
-                     /protein_id="AFG99682.1"
-                     /translation="MDSNTVSSFQVDCFLWHIRKQVVDQELSDAPFLDRLRRDQRSLRG
-                     RGNTLGLDIKAATHVGKQIVEKILKEESDEALKMTMASTPASRYITDMTIEELSRNWFM
-                     LMPKQKVEGPLCIRMDQAIMEKNIMLKANFSVIFDRLETLVLLRAFTEEGAIVGEISPL
-                     PSFPGHTIEDVKNAIGVLIGGLEWNDNTVRVSKNLQRFAWRSSNENGGPPLTPKQKRKM
-                     ARTARSKV"
-ORIGIN
-        1 acaaagacat aatggattcc aacactgtgt caagtttcca ggtagattgc tttctttggc
-       61 atatccggaa acaagttgta gaccaagaac tgagtgatgc cccattcctt gatcggcttc
-      121 gccgagatca gaggtcccta aggggaagag gcaacactct cggtctagac atcaaagcag
-      181 ccacccatgt tggaaagcag atagtagaaa agattctgaa ggaagaatct gatgaggcac
-      241 ttaaaatgac catggcctcc acacctgctt cgcgatacat aactgacatg actattgagg
-      301 aattgtcaag aaactggttc atgctaatgc ccaagcagaa agtggaagga cctctttgca
-      361 tcagaatgga ccaggcaatc atggagaaaa acatcatgtt gaaagcgaat ttcagtgtga
-      421 tctttgaccg actagagacc ctagtattac taagggcttt caccgaagag ggagcaattg
-      481 ttggcgaaat ctcaccattg ccttcttttc caggacatac tattgaggat gtcaaaaatg
-      541 caattggggt cctcatcgga ggacttgaat ggaatgataa cacagttcga gtctctaaaa
-      601 atctacagag attcgcttgg agaagcagta atgagaatgg gggacctcca cttactccaa
-      661 aacagaaacg gaaaatggcg agaacagcta ggtcaaaagt ttgaagagat aagatggctg
-      721 attgaagaag tgagacacag actaaaaaca actgagaata gttttgagca aataacattc
-      781 atgcaagcat tacagctgct gtttgaagtg gaacaggaga taagaacttt ctcatttcag
-      841 cttatttaat gataaaaaac accc
+                     /protein_id="AHX37634.1"
+                     /translation="MDSNTVSSFQVDCFLWHIRKQVVDQELSDAPFLDRLRRDQRSLR
+                     GRGNTLGLDIKAATHVGKQIVEKILKEESDEALKMTMVSTPASRYITDMTVEELSRNW
+                     FMLMPKQKMEGPLCIRMDQAIMEKNIMLKANFSVIFDRLETIVLLRAFTEEGAIVGEI
+                     SPLPSFPGHTIEDVKNAIGVLIGGLEWNDNTVRVSKNLQRFAWRSSNENGGSPLTPKQ
+                     KREMARTARSKV"
+ORIGIN      
+        1 gggtgacaaa gacataatgg attccaacac tgtgtcaagt ttccaggtag attgctttct
+       61 ttggcatatc cggaaacaag ttgtagacca agaactgagt gatgccccat tccttgatcg
+      121 gcttcgccga gatcagaggt ccctaagggg aagaggcaat actctcggtc tagacatcaa
+      181 agcagccacc catgttggaa agcaaattgt agaaaagatt ctgaaagaag aatctgatga
+      241 ggcacttaaa atgaccatgg tctccacacc tgcttcgcga tacataactg acatgactgt
+      301 tgaggaattg tcaagaaact ggttcatgct aatgcccaag cagaaaatgg aaggacctct
+      361 ttgcatcaga atggaccagg caatcatgga gaaaaacatc atgttgaaag cgaatttcag
+      421 tgtgattttt gaccgactag agaccatagt attactaagg gctttcaccg aagagggagc
+      481 aattgttggc gaaatctcac cattgccttc ttttccagga catactattg aggatgtcaa
+      541 aaatgcaatt ggggtcctca tcggaggact tgaatggaat gataacacag ttcgagtctc
+      601 taaaaatcta cagagattcg cttggagaag cagtaatgag aatgggggat ctccacttac
+      661 tccaaaacag aaacgggaaa tggcgagaac agctaggtca aaagtttgaa gagataagat
+      721 ggctaattga ggaagtgaga cacagattaa aaacaactga aaatagcttt gaacaaataa
+      781 cattcatgca agcattacaa ctgctgtttg aagtggaaca ggagataaga actttctcat
+      841 ttcagcttat ttaatgataa aaaaca
 //

--- a/config/reference_h3n2_pa.gb
+++ b/config/reference_h3n2_pa.gb
@@ -1,103 +1,114 @@
-LOCUS       CY113682                2192 bp    DNA              VRL 04-APR-2012
-DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) polymerase PA (PA) gene,
-            complete cds.
-ACCESSION   CY113682
-VERSION     CY113682.1
+LOCUS       KJ609205                2168 bp    cRNA    linear   VRL 25-MAR-2015
+DEFINITION  Influenza A virus (A/Perth/16/2009(H3N2)) segment 3 polymerase PA
+            (PA) and PA-X protein (PA-X) genes, complete cds.
+ACCESSION   KJ609205
+VERSION     KJ609205.1
 KEYWORDS    .
-SOURCE      Influenza A virus (A/Beijing/32/1992(H3N2))
-  ORGANISM  Influenza A virus (A/Beijing/32/1992(H3N2))
+SOURCE      Influenza A virus (A/Perth/16/2009(H3N2))
+  ORGANISM  Influenza A virus (A/Perth/16/2009(H3N2))
             Viruses; ssRNA viruses; ssRNA negative-strand viruses;
             Orthomyxoviridae; Influenzavirus A.
-REFERENCE   1  (bases 1 to 2192)
-  AUTHORS   Wentworth,D.E., Dugan,V., Halpin,R., Lin,X., Bera,J., Ghedin,E.,
-            Fedorova,N., Overton,L., Tsitrin,T., Stockwell,T., Amedeo,P.,
-            Bishop,B., Chen,H., Edworthy,P., Gupta,N., Katzel,D., Li,K.,
-            Schobel,S., Shrivastava,S., Thovarai,V., Wang,S., Westgeest,K.B.,
-            van Beek,R., Bestebroer,T.M., de Jong,J.C., Rimmelzwaan,G.F.,
-            Osterhaus,A.D.M.E., Fouchier,R.A.M., Bao,Y., Sanders,R.,
-            Dernovoy,D., Kiryutin,B., Lipman,D.J. and Tatusova,T.
-  TITLE     The NIAID Influenza Genome Sequencing Project
+REFERENCE   1  (bases 1 to 2168)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
+  TITLE     Innate immune response of BEAS-2B to influenza A (H3N2) viruses
   JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 2192)
-  CONSRTM   The NIAID Influenza Genome Sequencing Consortium
+REFERENCE   2  (bases 1 to 2168)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
   TITLE     Direct Submission
-  JOURNAL   Submitted (04-APR-2012) on behalf of JCVI/Erasmus Medical
-            College/NCBI, National Center for Biotechnology Information, NIH,
-            Bethesda, MD 20894, USA
-COMMENT     This work was supported by the National Institute of Allergy and
-            Infectious Diseases (NIAID), Genome Sequencing Centers for
-            Infectious Diseases (GSCID) program.
+  JOURNAL   Submitted (14-MAR-2014) Office of Cyber Infrastructure and
+            Computational Biology, National Institute of Allergy and Infectious
+            Diseases, 31 Center Drive, Room 3B62, Bethesda, MD 20892, USA
+COMMENT     GenBank Accession Numbers KJ609203-KJ609210 represent sequences
+            from the 8 segments of Influenza A virus (A/Perth/16/2009(H3N2)).
+            
+            ##Assembly-Data-START##
+            Assembly Method       :: SOAPdenovo2-bin-LINUX-generic-r240
+            Coverage              :: 2623
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
-     source          1..2192
-                     /bio_material="CEIRS#CIP047BE3292#"
-                     /collection_date="1992"
-                     /country="China: Beijing"
-                     /db_xref="taxon:380950"
-                     /host="Homo sapiens"
-                     /lab_host="xtMK3 MDCK1 passage(s)"
+     source          1..2168
+                     /organism="Influenza A virus (A/Perth/16/2009(H3N2))"
                      /mol_type="viral cRNA"
-                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
-                     /segment="3"
+                     /strain="A/Perth/16/2009"
                      /serotype="H3N2"
-                     /strain="A/Beijing/32/1992"
-     misc_feature    1..2192
-                     /db_xref="IRD:NIGSP_CEIRS_CIP047_RFH3_00116.PA"
-     gene            11..2161
+                     /host="Homo sapiens"
+                     /db_xref="taxon:654811"
+                     /segment="3"
+                     /country="Australia"
+                     /collection_date="07-Apr-2009"
+                     /note="passage details: E6, BEAS-2B 1"
+     misc_feature    1..2168
+                     /db_xref="IRD:IRD-Perth.3"
+     gene            5..2155
                      /gene="PA"
-     CDS             11..2161
+     CDS             5..2155
+                     /gene="PA"
                      /codon_start=1
-                     /gene="PA"
                      /product="polymerase PA"
-                     /protein_id="AFG99684.1"
-                     /translation="MEDFVRQCFNPMIVELAEKAMKEYGEDLKIETNKFAAICTHLEVC
-                     FMYSDFHFINEQGESIVVELDDPNALLKHRFEIIEGRDRTMAWTVVNSICNTTGAEKPK
-                     FLPDLYDYKENRFIEIGVTRREVHIYYLEKANKIKSENTHIHIFSFTGEEMATKADYTL
-                     DEESRARIKTRLFTIRQEMANRGLWDSFRQSERGEETIEEKFEISGTMRRLADQSLPPN
-                     FSCLENFRAYVDGFEPNGCIEGKLSQMSKEVNAKIEPFLKTTPRPIKLPNGPPCYQRSK
-                     FLLMDALKLSIEDPSHEGEGIPLYDAIKCIRTFFGWKEPYIVKPHEKGINSNYLLSWKQ
-                     VLAELQDIETEEKIPRTKNMKKTSQLKWALGENMAPEKVDFDNCRDISDLKQYDSDEPE
-                     LRSLSSWIQNEFNKACELTDSIWIELDEIGEDVAPIEYIASMRRNYFTAEVSHCRATEY
-                     IMKGVYINTALLNASCAAMDDFQLIPMISKCRTKEGRRKTNLYGFIIKGRSHLRNDTDV
-                     VNFVSMEFSLTDPRLEPHKWEKYCVLEIGDMLLRSAIGQMSRPMFLYVRTNGTSKIKMK
-                     WGMEMRRCLLQSLQQIESMIEAESSVKEKDMTKEFFENKSEAWPIGESPKGVEEGSIGK
-                     VCRTLLAKSVFNSLYASPQLEGFSAESRKLLLVVQALRDNLEPGTFDLGGLYEAIEECL
-                     INDPWVLLNASWFNSFLTHALK"
-ORIGIN
-        1 ctgattcgaa atggaagatt ttgtgcgaca atgcttcaac ccgatgattg tcgaacttgc
-       61 agaaaaggca atgaaagagt atggagagga tctgaaaatc gaaacaaaca aatttgcagc
-      121 aatatgcact cacttggagg tatgtttcat gtattcagat tttcatttca tcaatgaaca
-      181 aggcgaatca atagtggtag aacttgatga tccaaatgca ctgttaaagc acagatttga
-      241 aataatagag gggagagaca gaacaatggc ctggacagta gtaaacagta tctgcaacac
-      301 tactggagct gagaaaccga agtttctgcc agatttgtat gattacaagg agaacagatt
-      361 catcgaaatt ggagtaacaa ggagagaagt ccacatatat taccttgaaa aggccaataa
-      421 aattaaatct gagaatacac acatccacat tttctcattc actggggagg aaatggccac
-      481 aaaggcagac tacactctcg acgaggaaag cagggctagg attaagacca ggctatttac
-      541 cataagacaa gaaatggcca acagaggcct ctgggattcc tttcgtcagt ccgaaagagg
-      601 cgaagaaaca attgaagaaa aatttgaaat ctcaggaact atgcgcaggc ttgccgacca
-      661 aagtctcccg ccgaacttct cctgccttga gaattttaga gcctatgtgg atggattcga
-      721 accgaacggc tgcattgagg gcaagctttc tcaaatgtcc aaagaagtga atgccaaaat
-      781 tgaacctttt ctgaagacaa caccaagacc aatcaaactt ccgaatggac ctccttgtta
-      841 tcagcggtcc aaattccttc tgatggatgc tttaaaatta agcattgaag acccaagtca
-      901 cgaaggagag gggataccac tatatgatgc gatcaagtgc ataagaacat tctttggatg
-      961 gaaagagccc tatatagtca aaccacacga aaagggaata aattcaaatt acctgctgtc
-     1021 atggaagcaa gtactggcag aattgcagga cattgaaact gaggagaaga ttccaagaac
-     1081 taaaaacatg aagaaaacga gtcaactaaa gtgggctctt ggtgaaaaca tggcaccaga
-     1141 gaaagtagac tttgacaact gcagagacat aagcgatttg aagcaatatg atagtgacga
-     1201 acctgaattg aggtcacttt caagctggat acagaatgaa ttcaacaagg catgcgagct
-     1261 gactgattca atctggatag agctcgatga aattggagaa gacgtggccc caattgagta
-     1321 cattgcaagc atgaggagaa attatttcac agcagaggtg tcccattgca gagccactga
-     1381 atacataatg aagggggtat acattaatac tgccttgctc aatgcatcct gtgcagcaat
-     1441 ggacgatttt caactaattc ccatgataag caagtgcaga actaaagagg gaaggcgaaa
-     1501 aaccaattta tatggattca tcataaaagg aagatctcac ttaaggaatg acacagatgt
-     1561 ggtaaacttt gtgagcatgg agttttctct cactgacccg aggcttgagc cacataaatg
-     1621 ggagaaatac tgtgtccttg agataggaga tatgttacta agaagtgcca taggccaaat
-     1681 gtcaaggcct atgttcttgt atgtgaggac aaatggaaca tcaaagatca aaatgaaatg
-     1741 gggaatggag atgagacgtt gcctccttca gtcactccag cagatcgaga gcatgattga
-     1801 agccgagtcc tcggttaaag agaaagacat gaccaaagag ttttttgaga ataaatcaga
-     1861 agcatggccc attggggagt cccccaaggg agtggaagaa ggttccattg ggaaagtctg
-     1921 taggactttg ttggctaagt cggtgttcaa tagcctgtat gcatctccac aattagaagg
-     1981 attttcagcg gagtcaagaa aactgctcct tgttgttcag gctcttaggg acaaccttga
-     2041 acctgggacc tttgatcttg gggggctata tgaagcaatt gaggagtgcc tgattaatga
-     2101 tccctgggtt ttgctcaatg cgtcttggtt caactccttc ctaacacatg cattaaaata
-     2161 gttatggcag tgctactatt tgttatccat ac
+                     /protein_id="AHX37627.1"
+                     /translation="MEDFVRQCFNPMIVELAEKAMKEYGEDLKIETNKFAAICTHLEV
+                     CFMYSDFHFINEQGESIVVELDDPNALLKHRFELIEGRDRTMAWTVVNSICNTTGAGK
+                     PKFLPDLYDYKENRFIEIGVTRREVHIYYLEKANKIKSENTHIHIFSFTGEEMATKAD
+                     YTLDEESRARIKTRLFTIRQEMANRGLWDSFRQSERGEETIEEKFEITGTMRRLADQS
+                     LPPNFSCLENFRAYVDGFEPNGCIEGKLSQMSKEVNAQIEPFLKTTPRPIKLPNGPPC
+                     YQRSKFLLMDALKLSIEDPSHEGEGIPLYDAIKCIKTFFGWKEPYIVKPHEKGINSNY
+                     LLSWKQVLSELQDIENEEKVPRTKNMKKTSQLKWALGENMAPEKVDFENCRDISDLKQ
+                     YDSDEPELRSLSSWIQNEFNKACELTDSVWIELDEIGEDVAPIEHIASMRRNYFTAEV
+                     SHCRATEYIMKGVYINTALLNASCAAMDDFQLIPMISKCRTKEGRRKTNLYGFIIKGR
+                     SHLRNDTDVVNFVSMEFSLTDPRLEPHKWEKYCVLEIGDMLLRSAIGQISRPMFLYVR
+                     TNGTSKVKMKWGMEMRRCLLQSLQQIESMIEAESSVKEKDMTKEFFENKSEAWPIGES
+                     PKGVEEGSIGKVCRTLLAKSVFNSLYASPQLEGFSAESRKLLLVVQALRDNLEPGTFD
+                     LGGLYEAIEECLINDPWVLLNASWFNSFLTHALK"
+     gene            5..764
+                     /gene="PA-X"
+     CDS             join(5..574,576..764)
+                     /gene="PA-X"
+                     /ribosomal_slippage
+                     /codon_start=1
+                     /product="PA-X protein"
+                     /protein_id="AHX37628.1"
+                     /translation="MEDFVRQCFNPMIVELAEKAMKEYGEDLKIETNKFAAICTHLEV
+                     CFMYSDFHFINEQGESIVVELDDPNALLKHRFELIEGRDRTMAWTVVNSICNTTGAGK
+                     PKFLPDLYDYKENRFIEIGVTRREVHIYYLEKANKIKSENTHIHIFSFTGEEMATKAD
+                     YTLDEESRARIKTRLFTIRQEMANRGLWDSFVSPKEAKKQLKKNLKSQELCVGLPTKV
+                     SHRTSPALRILEPMWMDSNRTAALRASFLKCPKK"
+ORIGIN      
+        1 cgaaatggaa gattttgtgc gacaatgctt caacccgatg attgtcgaac ttgcagaaaa
+       61 agcaatgaaa gagtatgggg aggatctgaa aattgaaaca aacaaatttg cagcaatatg
+      121 cactcacttg gaggtgtgtt tcatgtattc agatttccat ttcatcaatg aacaaggcga
+      181 atcaatagtg gtagaacttg acgatccaaa tgcactgtta aagcacagat ttgaactaat
+      241 cgaggggaga gacagaacaa tggcctggac agtagtaaac agtatctgca acactactgg
+      301 agctgggaaa ccgaagtttc taccagattt gtatgattac aaggagaaca gattcatcga
+      361 aattggggtg acaaggagag aagtccacat atattacctt gaaaaggcca ataagattaa
+      421 atctgagaac acacacattc acattttctc attcactgga gaggaaatgg ccacaaaggc
+      481 agactacact ctcgacgagg aaagcagggc taggattaag accaggctgt ttaccataag
+      541 acaagaaatg gccaacagag gcctatggga ttcctttcgt cagtccgaaa gaggcgaaga
+      601 aacaattgaa gaaaaatttg aaatcacagg aactatgcgt aggcttgccg accaaagtct
+      661 cccaccgaac ttctcctgcc ttgagaattt tagagcctat gtggatggat tcgaaccgaa
+      721 cggctgcatt gagggcaagc tttctcaaat gtccaaagaa gtgaatgccc aaattgaacc
+      781 ttttctgaag acaacaccaa gaccaatcaa acttccgaat ggacctcctt gttatcagcg
+      841 gtccaaattc ctcctgatgg atgctttaaa attgagcatt gaagacccaa gtcacgaagg
+      901 agaagggatc ccattatatg atgcgatcaa gtgcataaaa acattctttg gatggaaaga
+      961 accttatata gtcaaaccac acgaaaaggg aataaattca aattacctgc tgtcatggaa
+     1021 gcaagtactg tcagaattgc aggacattga aaatgaggag aaggttccaa ggactaaaaa
+     1081 catgaagaaa acgagtcaac ttaagtgggc tcttggtgaa aacatggcac cagagaaggt
+     1141 agactttgaa aactgcagag acataagcga tttgaagcaa tatgatagtg acgaacctga
+     1201 attaaggtca ctttcaagct ggatacagaa tgagttcaac aaggcctgtg agctaactga
+     1261 ttcagtctgg atagagctcg atgaaattgg agaggacgta gccccaattg agcacattgc
+     1321 aagcatgaga aggaattatt tcacagcaga ggtgtcccat tgtagagcca ctgaatacat
+     1381 aatgaagggg gtatacatta acactgccct gctcaatgca tcctgtgcag caatggacga
+     1441 ttttcaacta attcccatga taagcaagtg cagaactaaa gagggaaggc gaaaaaccaa
+     1501 tttatatgga ttcatcataa agggaagatc tcatttaagg aatgacacag acgtggtaaa
+     1561 ttttgtgagc atggagtttt ctctcactga cccgagactt gagccacata aatgggagaa
+     1621 atactgtgtc cttgagatag gagatatgtt actaagaagt gccataggcc aaatttcaag
+     1681 gccaatgttc ttatatgtga ggacaaacgg aacatcaaag gtcaaaatga aatggggaat
+     1741 ggagatgaga cgttgcctcc ttcagtcact ccagcagatc gagagcatga ttgaagccga
+     1801 gtcctcggtt aaagagaaag acatgaccaa agagtttttt gagaataaat cagaagcatg
+     1861 gcccattggg gagtccccca agggagtgga agaaggttcc attgggaaag tctgtaggac
+     1921 tctattggct aagtcagtat tcaatagcct gtatgcatca ccacaattgg aaggattttc
+     1981 agcggagtca agaaaactgc tccttgttgt tcaggctctt agggacaacc tcgaacctgg
+     2041 gacctttgat cttggggggc tatatgaagc aattgaggag tgcctgatta atgatccctg
+     2101 ggttttgctc aatgcgtctt ggttcaactc cttcctgaca catgcattaa aatagttatg
+     2161 gcagtgct
 //

--- a/config/reference_h3n2_pb1.gb
+++ b/config/reference_h3n2_pb1.gb
@@ -1,115 +1,113 @@
-LOCUS       CY113683                2311 bp    DNA              VRL 04-APR-2012
-DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) polymerase PB1 (PB1) and
-            PB1-F2 protein (PB1-F2) genes, complete cds.
-ACCESSION   CY113683
-VERSION     CY113683.1
+LOCUS       KJ609204                2304 bp    cRNA    linear   VRL 25-MAR-2015
+DEFINITION  Influenza A virus (A/Perth/16/2009(H3N2)) segment 2 polymerase PB1
+            (PB1) and PB1-F2 protein (PB1-F2) genes, complete cds.
+ACCESSION   KJ609204
+VERSION     KJ609204.1
 KEYWORDS    .
-SOURCE      Influenza A virus (A/Beijing/32/1992(H3N2))
-  ORGANISM  Influenza A virus (A/Beijing/32/1992(H3N2))
+SOURCE      Influenza A virus (A/Perth/16/2009(H3N2))
+  ORGANISM  Influenza A virus (A/Perth/16/2009(H3N2))
             Viruses; ssRNA viruses; ssRNA negative-strand viruses;
             Orthomyxoviridae; Influenzavirus A.
-REFERENCE   1  (bases 1 to 2311)
-  AUTHORS   Wentworth,D.E., Dugan,V., Halpin,R., Lin,X., Bera,J., Ghedin,E.,
-            Fedorova,N., Overton,L., Tsitrin,T., Stockwell,T., Amedeo,P.,
-            Bishop,B., Chen,H., Edworthy,P., Gupta,N., Katzel,D., Li,K.,
-            Schobel,S., Shrivastava,S., Thovarai,V., Wang,S., Westgeest,K.B.,
-            van Beek,R., Bestebroer,T.M., de Jong,J.C., Rimmelzwaan,G.F.,
-            Osterhaus,A.D.M.E., Fouchier,R.A.M., Bao,Y., Sanders,R.,
-            Dernovoy,D., Kiryutin,B., Lipman,D.J. and Tatusova,T.
-  TITLE     The NIAID Influenza Genome Sequencing Project
+REFERENCE   1  (bases 1 to 2304)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
+  TITLE     Innate immune response of BEAS-2B to influenza A (H3N2) viruses
   JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 2311)
-  CONSRTM   The NIAID Influenza Genome Sequencing Consortium
+REFERENCE   2  (bases 1 to 2304)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
   TITLE     Direct Submission
-  JOURNAL   Submitted (04-APR-2012) on behalf of JCVI/Erasmus Medical
-            College/NCBI, National Center for Biotechnology Information, NIH,
-            Bethesda, MD 20894, USA
-COMMENT     This work was supported by the National Institute of Allergy and
-            Infectious Diseases (NIAID), Genome Sequencing Centers for
-            Infectious Diseases (GSCID) program.
+  JOURNAL   Submitted (14-MAR-2014) Office of Cyber Infrastructure and
+            Computational Biology, National Institute of Allergy and Infectious
+            Diseases, 31 Center Drive, Room 3B62, Bethesda, MD 20892, USA
+COMMENT     GenBank Accession Numbers KJ609203-KJ609210 represent sequences
+            from the 8 segments of Influenza A virus (A/Perth/16/2009(H3N2)).
+            
+            ##Assembly-Data-START##
+            Assembly Method       :: SOAPdenovo2-bin-LINUX-generic-r240
+            Coverage              :: 2795
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
-     source          1..2311
-                     /bio_material="CEIRS#CIP047BE3292#"
-                     /collection_date="1992"
-                     /country="China: Beijing"
-                     /db_xref="taxon:380950"
-                     /host="Homo sapiens"
-                     /lab_host="xtMK3 MDCK1 passage(s)"
+     source          1..2304
+                     /organism="Influenza A virus (A/Perth/16/2009(H3N2))"
                      /mol_type="viral cRNA"
-                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
-                     /segment="2"
+                     /strain="A/Perth/16/2009"
                      /serotype="H3N2"
-                     /strain="A/Beijing/32/1992"
-     misc_feature    1..2311
-                     /db_xref="IRD:NIGSP_CEIRS_CIP047_RFH3_00116.PB1"
-     gene            10..2283
+                     /host="Homo sapiens"
+                     /db_xref="taxon:654811"
+                     /segment="2"
+                     /country="Australia"
+                     /collection_date="07-Apr-2009"
+                     /note="passage details: E6, BEAS-2B 1"
+     misc_feature    1..2304
+                     /db_xref="IRD:IRD-Perth.2"
+     gene            1..2274
                      /gene="PB1"
-     CDS             10..2283
+     CDS             1..2274
+                     /gene="PB1"
                      /codon_start=1
-                     /gene="PB1"
                      /product="polymerase PB1"
-                     /protein_id="AFG99685.1"
-                     /translation="MDVNPTLLFLKVPAQNAISTTFPYTGDPPYSHGTGTGYTMDTVNR
-                     THQYSERGKWTTNTETGAPQLNPIDGPLPEDNEPSGYAQTDCVLEAMAFLEESHPGIFE
-                     NSCLETMEVVQQTRVDKLTQGRQTYDWTLNRNQPAATALANTIEVFRSNGLTANESGRL
-                     IDFLKDVMESMDKEEIEIITHFQRKRRVRDNMTKKMVTQRTIGKKKQRVNKRSYLIRAL
-                     TLNTMTKDAERGKLKRRAIATPGMQIRGFVYFVETLARSICEKLEQSGLPVGGNEKKAK
-                     LANVVRKMMTNSQDTELSFTITGDNTKWNENQNPRMFLAMITYITKNQPEWFRNILSIA
-                     PIMFSNKMARLGKGYMFESKRMKLRTQIPAEMLASIDLKYFNESTRKKIEKIRPLLIDG
-                     TASLSPGMMMGMFNMLSTVLGVSILNLGQKKYTKTTYWWDGLQSSDDFALIVNAPNHEG
-                     IQAGVDRFYRTCKLVGINMSKKKSYINKTGTFEFTSFFYRYGFVANFSMELPSFGVSGI
-                     NESADMSIGVTVIKNNMINNDLGPATAQMALQLFIKDYRYTYRCHRGDTQIQTRRSFEL
-                     KKLWDQTQSKAGLLVSDGGPNLYNIRNLHIPEVCLKWELMDEDYQGRLCNPLNPFVSHK
-                     EIESVNNAVVMPAHGPAKSMEYDAVATTHSWIPKRNRSILNTSQRGILEDEQMYQKCCN
-                     LFEKFFPSSSYRRPVGISSMVEAMVSRARIDARIDFESGRIKKEEFSEIMKICSTIEEL
-                     RRQK"
-     gene            104..376
+                     /protein_id="AHX37625.1"
+                     /translation="MDVNPTLLFLKVPAQNAISTTFPYTGDPPYSHGTGTGYTMDTVN
+                     RTHQYSERGKWTTNTETGAPQLNPIDGPLPEDNEPSGYAQTDCVLEAMAFLEESHPGI
+                     FENSCLETMEAVQQTRVDKLTQGRQTYDWTLNRNQPAATALANTIEVFRSNGLTANES
+                     GRLIDFLKDVMESMDKEEMEITTHFQRKRRVRDNMTKKMVTQRTIGKKKQRVNKRGYL
+                     IRALTLNTMTKDAERGKLKRRAIATPGMQIRGFVYFVETLARSICEKLEQSGLPVGGN
+                     EKKAKLANVVRKMMTNSQDTELSFTITGDNTKWNENQNPRMFLAMITYITKNQPEWFR
+                     NILSIAPIMFSNKMARLGKGYMFESKRMKLRTQIPAEMLASIDLKYFNESTRKKIEKI
+                     RPLLIDGTASLSPGMMMGMFNMLSTVLGVSILNLGQKKYTKTTYWWDGLQSSDDFALI
+                     VNAPNHEGIQAGVDRFYRTCKLVGINMSKKKSYINKTGTFEFTSFFYRYGFVANFSME
+                     LPSFGVSGINESADMSIGVTVIKNNMINNDLGPATAQMALQLFIKDYRYTYRCHRGDT
+                     QIQTRRSFEIKKLWDQTQSRAGLLVSDGGPNLYNIRNLHIPEVCLKWELMDENYRGRL
+                     CNPLNPFVSHKEIESVNNAVVMPAHGPAKSMEYDAVATTHSWIPKRNRSILNTSQRGI
+                     LEDEQMYQKCCNLFEKFFPSSSYRRPIGISSMVEAMVSRARIDARIDFESGRIKKEEF
+                     SEIMKICSTIEELRRQK"
+     gene            95..367
                      /gene="PB1-F2"
-     CDS             104..376
+     CDS             95..367
+                     /gene="PB1-F2"
                      /codon_start=1
-                     /gene="PB1-F2"
                      /product="PB1-F2 protein"
-                     /protein_id="AFG99686.1"
-                     /translation="MEQEQDTPWTQSTEHINIQKGGSGQQTQKLGHPNSTRLMDHYPRI
-                     MSQVDMHKQTVFWRPWLSLRNPTQGSLRTHALRQWKSFNKQGWTN"
-ORIGIN
-        1 accatttgaa tggatgtcaa tccgactcta cttttcctaa aggttccagc tcaaaatgcc
-       61 ataagcacca cattccctta tactggagat cctccataca gccatggaac aggaacagga
-      121 tacaccatgg acacagtcaa cagaacacat caatattcag aaagggggaa gtggacaaca
-      181 aacacagaaa ctggggcacc ccaactcaac ccgattgatg gaccactacc cgaggataat
-      241 gagccaagtg gatatgcaca aacagactgt gttctggagg ccatggcttt ccttgaggaa
-      301 tcccacccag ggatctttga gaactcatgc cttgagacaa tggaagtcgt tcaacaaaca
-      361 agggtggaca aactgaccca aggtcgccag acctatgatt ggacattaaa cagaaatcaa
-      421 ccggcagcaa ctgcattagc caacaccata gaagttttta gatcgaatgg tttaacagca
-      481 aatgagtcag gaaggctaat agatttcctc aaggatgtaa tggaatcaat ggataaggag
-      541 gaaatagaga taataacaca ctttcaaaga aaaaggagag taagagacaa catgaccaag
-      601 aaaatggtca cacaaagaac aatagggaag aaaaaacaga gagtgaataa gagaagctat
-      661 ctaataagag cattgacatt gaacacgatg accaaagatg cagaaagagg taagttaaaa
-      721 agaagggcta ttgcaacacc cgggatgcaa atcagagggt tcgtgtactt tgttgaaact
-      781 ttagctagga gcatttgcga aaaacttgaa cagtctggac ttccagttgg gggtaatgaa
-      841 aagaaagcca aactggcaaa tgttgtgaga aagatgatga ccaattcaca agacacagag
-      901 ctttctttca caatcactgg ggacaatact aagtggaatg aaaatcaaaa tcctcgaatg
-      961 ttcctggcga tgattacata tataacaaaa aatcaacctg agtggttcag aaacatcctg
-     1021 agcatcgcac ccataatgtt ctcaaacaaa atggcaagac taggaaaagg atacatgttc
-     1081 gaaagtaaga gaatgaaact ccgaacacaa ataccagcag aaatgctagc aagcattgac
-     1141 ctgaagtatt tcaatgaatc aacaaggaag aaaattgaga aaataaggcc tcttctaata
-     1201 gatggcacag catcattgag ccctggaatg atgatgggca tgttcaacat gctaagtacg
-     1261 gttttaggag tctcgatact gaatcttgga caaaagaaat acaccaaaac aacatactgg
-     1321 tgggatggac tccaatcctc cgacgatttt gccctcatag ttaatgcacc aaatcatgag
-     1381 ggaatacaag caggagtgga taggttctac aggacctgca agttagtggg aatcaacatg
-     1441 agcaaaaaga agtcctacat aaataagaca gggacatttg aattcacaag ctttttttat
-     1501 cgctatggat ttgtggctaa ttttagcatg gagctgccca gttttggagt gtctggaata
-     1561 aatgaatcag ctgatatgag cattggagta acagtgataa agaacaacat gataaacaat
-     1621 gaccttggac cagcaacagc ccagatggct cttcaattgt tcatcaaaga ctacagatat
-     1681 acatatcggt gccacagagg agacacacaa attcagacga gaagatcatt cgagctaaag
-     1741 aagctgtggg atcaaaccca atcaaaggca ggactattag tatcagatgg aggaccaaac
-     1801 ttatacaata ttcggaatct tcacattcct gaagtctgct taaagtggga gctaatggat
-     1861 gaggattatc agggaagact ttgtaatccc ctgaatccat tcgtcagcca taaagagatt
-     1921 gagtctgtaa acaatgctgt ggtaatgcca gcccatggtc cagccaagag catggaatat
-     1981 gatgccgttg caactacaca ttcctggatt cccaagagga accgctctat tctcaacaca
-     2041 agccaaaggg gaattcttga ggatgaacag atgtatcaga agtgctgcaa cttgttcgag
-     2101 aaatttttcc ccagtagttc atacaggaga ccggttggga tttctagcat ggtggaggcc
-     2161 atggtgtcta gggcccggat tgatgccaga attgacttcg agtctggacg gattaagaaa
-     2221 gaagagttct ccgagatcat gaagatctgt tccaccattg aagaactcag acggcaaaaa
-     2281 taatgaattt agcttgtcct tcatgaaaaa a
+                     /protein_id="AHX37626.1"
+                     /translation="MEQEQGTPWTQSTEHTNIQRGGSGRQIQKLGHPNSTQLMDHYLR
+                     IMNQVDMHKQTVSWRLWPSLKNPTQVSLRTHALKQWKPFNRQGWTN"
+ORIGIN      
+        1 atggatgtca atccgactct actgttccta aaagttccag cgcaaaatgc cataagcaca
+       61 acattccctt atactggaga tcctccatac agccatggaa caggaacagg gtacaccatg
+      121 gacacagtca acagaacaca ccaatattca gagaggggga agtggacgac aaatacagaa
+      181 actggggcac cccaactcaa cccaattgat ggaccactac ctgaggataa tgaaccaagt
+      241 ggatatgcac aaacagactg tgtcctggag gctatggcct tccttgaaga atcccaccca
+      301 ggtatctttg agaactcatg ccttgaaaca atggaagccg ttcaacagac aagggtggac
+      361 aaactaaccc aaggtcgcca gacttatgat tggacattaa acagaaatca accggcagca
+      421 actgcattag ccaacaccat agaagttttt agatcgaacg gattaacagc taatgaatca
+      481 ggaaggctaa tagatttcct caaggatgtg atggaatcaa tggataaaga ggaaatggag
+      541 ataacaacac actttcaaag aaaaaggaga gtaagggaca acatgaccaa gaaaatggtc
+      601 acacaaagaa caatagggaa gaaaaaacaa agagtgaata agagaggcta cctaataaga
+      661 gctttgacat tgaacacgat gaccaaagat gcagagagag gcaaattaaa aagaagggct
+      721 attgcaacac ccgggatgca aattagaggg ttcgtgtact tcgttgaaac tttagctaga
+      781 agcatttgcg aaaagcttga acagtctgga cttccggttg ggggtaatga aaagaaggcc
+      841 aaactggcaa atgttgtgag aaaaatgatg actaactcac aagacacaga gctttctttc
+      901 acaatcactg gggacaacac taagtggaat gaaaatcaaa accctcgaat gtttttggcg
+      961 atgattacat acatcacaaa gaatcaacct gagtggttca gaaacatcct gagcatcgca
+     1021 ccaataatgt tctcaaacaa aatggcaaga ttgggaaaag gatacatgtt cgagagtaag
+     1081 agaatgaagc tccggacaca aatacctgca gaaatgctag caagcattga cctgaagtat
+     1141 ttcaatgaat caacaaggaa gaaaattgag aaaataaggc ctcttctaat agatggcaca
+     1201 gcatcattga gccctggaat gatgatgggc atgttcaaca tgctaagtac ggttttagga
+     1261 gtctcgatac tgaatcttgg acaaaagaaa tacaccaaga caacatactg gtgggatggg
+     1321 ctccaatcct ccgacgattt tgccctcata gtgaatgcac caaatcatga gggaatacaa
+     1381 gcaggagtgg atagattcta caggacctgc aagttagtgg gaatcaacat gagcaaaaag
+     1441 aagtcctata taaataaaac agggacattt gaattcacta gcttttttta tcgatatgga
+     1501 tttgtggcta attttagcat ggagctgccc agttttggag tgtctggaat aaacgagtca
+     1561 gctgatatga gcattggagt aacagtgata aagaacaaca tgataaacaa tgaccttgga
+     1621 ccagcaacag cccaaatggc tctccaattg ttcatcaaag attacagata cacatatagg
+     1681 tgccatagag gagacacaca aatccagacg agaagatcat tcgagataaa gaagctgtgg
+     1741 gatcaaaccc aatcaagggc aggactattg gtatcagatg ggggaccaaa cttatacaat
+     1801 atccggaatc ttcacatccc tgaagtctgc ttaaaatggg agctgatgga tgagaattat
+     1861 cggggaagac tttgtaatcc cctgaatccc tttgtcagcc ataaagaaat tgagtctgta
+     1921 aacaatgctg tagtaatgcc agcccatggt cctgccaaaa gtatggaata tgatgccgtt
+     1981 gcaactacac actcctggat tcccaagagg aaccgctcta ttctaaacac aagccaaagg
+     2041 ggaattcttg aggatgaaca gatgtaccag aagtgctgca acttgttcga gaaatttttc
+     2101 cctagtagtt catataggag accgattgga atttctagca tggtggaggc catggtgtct
+     2161 agggcccgga ttgatgccag aattgacttc gagtctggaa ggattaagaa ggaagagttc
+     2221 tctgagatca tgaagatctg ttccaccatt gaagaactca gacggcaaaa ataatgaatt
+     2281 tagcttgtcc ttcatgaaaa aatg
 //

--- a/config/reference_h3n2_pb2.gb
+++ b/config/reference_h3n2_pb2.gb
@@ -1,106 +1,104 @@
-LOCUS       CY113684                2310 bp    DNA              VRL 04-APR-2012
-DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) polymerase PB2 (PB2)
-            gene, complete cds.
-ACCESSION   CY113684
-VERSION     CY113684.1
+LOCUS       KJ609203                2292 bp    cRNA    linear   VRL 25-MAR-2015
+DEFINITION  Influenza A virus (A/Perth/16/2009(H3N2)) segment 1 polymerase PB2
+            (PB2) gene, complete cds.
+ACCESSION   KJ609203
+VERSION     KJ609203.1
 KEYWORDS    .
-SOURCE      Influenza A virus (A/Beijing/32/1992(H3N2))
-  ORGANISM  Influenza A virus (A/Beijing/32/1992(H3N2))
+SOURCE      Influenza A virus (A/Perth/16/2009(H3N2))
+  ORGANISM  Influenza A virus (A/Perth/16/2009(H3N2))
             Viruses; ssRNA viruses; ssRNA negative-strand viruses;
             Orthomyxoviridae; Influenzavirus A.
-REFERENCE   1  (bases 1 to 2310)
-  AUTHORS   Wentworth,D.E., Dugan,V., Halpin,R., Lin,X., Bera,J., Ghedin,E.,
-            Fedorova,N., Overton,L., Tsitrin,T., Stockwell,T., Amedeo,P.,
-            Bishop,B., Chen,H., Edworthy,P., Gupta,N., Katzel,D., Li,K.,
-            Schobel,S., Shrivastava,S., Thovarai,V., Wang,S., Westgeest,K.B.,
-            van Beek,R., Bestebroer,T.M., de Jong,J.C., Rimmelzwaan,G.F.,
-            Osterhaus,A.D.M.E., Fouchier,R.A.M., Bao,Y., Sanders,R.,
-            Dernovoy,D., Kiryutin,B., Lipman,D.J. and Tatusova,T.
-  TITLE     The NIAID Influenza Genome Sequencing Project
+REFERENCE   1  (bases 1 to 2292)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
+  TITLE     Innate immune response of BEAS-2B to influenza A (H3N2) viruses
   JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 2310)
-  CONSRTM   The NIAID Influenza Genome Sequencing Consortium
+REFERENCE   2  (bases 1 to 2292)
+  AUTHORS   Oler,A.J. and Fabozzi,G.
   TITLE     Direct Submission
-  JOURNAL   Submitted (04-APR-2012) on behalf of JCVI/Erasmus Medical
-            College/NCBI, National Center for Biotechnology Information, NIH,
-            Bethesda, MD 20894, USA
-COMMENT     This work was supported by the National Institute of Allergy and
-            Infectious Diseases (NIAID), Genome Sequencing Centers for
-            Infectious Diseases (GSCID) program.
+  JOURNAL   Submitted (14-MAR-2014) Office of Cyber Infrastructure and
+            Computational Biology, National Institute of Allergy and Infectious
+            Diseases, 31 Center Drive, Room 3B62, Bethesda, MD 20892, USA
+COMMENT     GenBank Accession Numbers KJ609203-KJ609210 represent sequences
+            from the 8 segments of Influenza A virus (A/Perth/16/2009(H3N2)).
+            
+            ##Assembly-Data-START##
+            Assembly Method       :: SOAPdenovo2-bin-LINUX-generic-r240
+            Coverage              :: 1839
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
-     source          1..2310
-                     /bio_material="CEIRS#CIP047BE3292#"
-                     /collection_date="1992"
-                     /country="China: Beijing"
-                     /db_xref="taxon:380950"
-                     /host="Homo sapiens"
-                     /lab_host="xtMK3 MDCK1 passage(s)"
+     source          1..2292
+                     /organism="Influenza A virus (A/Perth/16/2009(H3N2))"
                      /mol_type="viral cRNA"
-                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
-                     /segment="1"
+                     /strain="A/Perth/16/2009"
                      /serotype="H3N2"
-                     /strain="A/Beijing/32/1992"
-     misc_feature    1..2310
-                     /db_xref="IRD:NIGSP_CEIRS_CIP047_RFH3_00116.PB2"
-     gene            13..2292
+                     /host="Homo sapiens"
+                     /db_xref="taxon:654811"
+                     /segment="1"
+                     /country="Australia"
+                     /collection_date="07-Apr-2009"
+                     /note="passage details: E6, BEAS-2B 1"
+     misc_feature    1..2292
+                     /db_xref="IRD:IRD-Perth.1"
+     gene            3..2282
                      /gene="PB2"
-     CDS             13..2292
+     CDS             3..2282
+                     /gene="PB2"
                      /codon_start=1
-                     /gene="PB2"
                      /product="polymerase PB2"
-                     /protein_id="AFG99687.1"
-                     /translation="MERIKELRNLMSQSRTREILTKTTVDHMAIIKKYTSGRQEKNPSL
-                     RMKWMMAMKYPITADKRITEMVPERNEQGQTLWSKMSDAGSDRVMVSPLAVTWWNRNGP
-                     VTNTVHYPKVYKTYFDKVERLKHGTFGPVHFRNQVKIRRRVDINPGHADLSAKEAQDVI
-                     MEVVFPNEVGARILTSESQLTITKEKKEELRDCKISPLMVAYMLERELVRKTRFLPVAG
-                     GTSSIYIEVLHLTQGTCWEQMYTPGGEVRNDDVDQSLIIAARNIVRRAAVSADPLASLL
-                     EMCHSTQIGGTRMVDILRQNPTEEQAVDICKAAMGLRISSSFSFGGFTFKRTSGSSVKR
-                     EEEVLTGNLQTLKIRVHEGYEEFTMVGKRATAILRKATRRLVQLIVSGRDEQSIAEAII
-                     VAMVFSQEDCMIKAVRGDLNFVNRANQRLNPMHQLLRHFQKDAKVLFQNWGIEHIDSVM
-                     GMVGVLPDMTPSTEMSMRGIRVSKMGVDEYSSTERVVVSIDRFLRVRDQRGNVLLSPEE
-                     VSETQGTERLTITYSSSMMWEINGPESVLVNTYQWVIRNWETVKIQWSQNPAMLYNKME
-                     FEPFQSLVPKAIRGQYSGFVRTLFQQMRDVLGTFDTTQIIKLLPFAAAPPKQSRMQFSS
-                     LTVNVRGSGMRILVRGNSPVFNYNKTTKRLTILGKDAGTLIEDPDESTSGVESAVLRGF
-                     LILGKEDRRYGPALSINELSNLAKGEKANVLIGQGDVVLVMKRKRDSSILTDSQTATKR
-                     IRMAIN"
-ORIGIN
-        1 attatattca gtatggaaag aataaaagaa ctacggaacc tgatgtcgca gtctcgcact
-       61 cgcgagatac taacaaaaac cacagtggac catatggcca taattaagaa gtacacatca
-      121 gggagacagg aaaagaaccc gtcacttagg atgaaatgga tgatggcaat gaaatatcca
-      181 atcactgctg acaaaaggat aacagaaatg gttccggaga gaaatgaaca aggacaaact
-      241 ctatggagta aaatgagtga tgctgggtca gatcgagtga tggtatcacc tttggcagtg
-      301 acatggtgga atagaaatgg accagtgaca aatacggttc actatccaaa agtctacaag
-      361 acttattttg acaaagtcga aaggttaaaa catggaacct ttggccctgt ccattttaga
-      421 aatcaagtca aaatacgccg aagagtagac ataaacccgg gtcatgcaga cctcagtgcc
-      481 aaggaggcac aagatgtaat tatggaagtt gttttcccca atgaagtggg agccaggata
-      541 ctaacatcag aatcacaatt aacaataacc aaagagaaaa aagaagaact ccgagattgc
-      601 aaaatttctc ctttgatggt tgcatacatg ttagagagag aacttgtccg aaaaacgaga
-      661 tttctcccag ttgctggcgg aacaagcagt atatacattg aagttttaca tttgactcaa
-      721 ggaacgtgtt gggaacaaat gtacactcca ggtggagaag tgaggaatga cgatgttgac
-      781 caaagcctaa ttattgcagc caggaacata gtgagaagag ccgcagtatc agcagatcca
-      841 ctagcatctt tattggagat gtgccacagc acacaaattg gcgggacaag gatggtggac
-      901 attcttaggc agaacccgac ggaagaacaa gctgtggata tatgcaaggc tgcaatggga
-      961 ttgagaatca gctcatcctt cagctttggt gggttcacat ttaaaagaac aagcgggtcc
-     1021 tcagtcaaaa gagaggaaga agtgcttaca ggcaatctcc aaacattgaa aataagagta
-     1081 catgaggggt acgaggagtt cacaatggtg gggaaaagag caacagctat actcagaaaa
-     1141 gcaaccagga gattggttca gctcatagtg agtggaaggg acgaacagtc aatagccgaa
-     1201 gcaataatcg tggccatggt gttttcacaa gaggattgca tgataaaagc agttagaggt
-     1261 gacctgaatt tcgttaacag ggcaaatcag cggttgaatc ccatgcatca gcttttaagg
-     1321 cattttcaga aagatgcgaa agtgcttttt cagaattggg gaattgaaca catcgacagt
-     1381 gtgatgggaa tggttggagt attaccagat atgactccaa gcacagagat gtcaatgaga
-     1441 ggaataagag tcagcaaaat gggcgtggat gaatactcca gcacagagag ggtggtggtt
-     1501 agcattgatc ggtttttgag agttcgagac caacgtggga atgtattatt atctcctgag
-     1561 gaggtcagtg aaacacaggg aacagagaga ctgacaataa cttactcatc gtcaatgatg
-     1621 tgggagatta acggccctga gtcggttttg gtcaatacct atcaatgggt catcagaaat
-     1681 tgggaaactg tcaaaattca atggtctcag aatcctgcaa tgttgtacaa caaaatggaa
-     1741 tttgaaccat ttcaatcttt agttcctaag gccattagag gccaatacag tggatttgtc
-     1801 agaactctat tccaacaaat gagagatgta cttgggacat ttgataccac ccagataata
-     1861 aagcttctcc cttttgcagc cgctccacca aagcaaagca gaatgcagtt ctcttcattg
-     1921 actgtaaatg tgaggggatc agggatgaga atacttgtaa ggggcaattc tcctgtattc
-     1981 aactacaaca agaccactaa aagactaaca attctcggaa aagatgccgg cactttaatt
-     2041 gaagacccag atgaaagcac atccggagtg gagtccgctg tcttgagagg atttctcatt
-     2101 ctaggtaagg aagacagaag atacggacca gcattaagca tcaatgaact gagtaacctt
-     2161 gcaaaagggg aaaaggctaa tgtgctaatt gggcaaggag acgtggtgtt ggtaatgaaa
-     2221 cgaaaacggg actctagcat acttactgac agccagacag cgaccaaaag aattcggatg
-     2281 gccatcaatt aatgttgaat agtttaaaaa
+                     /protein_id="AHX37624.1"
+                     /translation="MERIKELRNLMSQSRTREILTKTTVDHMAIIKKYTSGRQEKNPS
+                     LRMKWMMAMKYPITADKRITEMVPERNEQGQTLWSKMSDAGSDRVMVSPLAVTWWNRN
+                     GPVTSTVHYPKVYKTYFDKVERLKHGTFGPVHFRNQVKIRRRVDINPGHADLSAKEAQ
+                     DVIMEVVFPNEVGARILTSESQLTITKEKKEELRDCKISPLMVAYMLERELVRKTRFL
+                     PVAGGTSSIYIEVLHLTQGTCWEQMYTPGGGVRNDDVDQSLIIAARNIVRRAAVSADP
+                     LASLLEMCHSTQIGGTRMVDILRQNPTEEQAVDICKAAMGLRISSSFSFGGFTFKRTS
+                     GSSVKKEEEVLTGNLQTLRIRVHEGYEEFTMVGKRATAILRKATRRLVQLIVSGRDEQ
+                     SIAEAIIVAMVFSQEDCMIKAVRGDLNFVNRANQRLNPMHQLLRHFQKDAKVLFQNWG
+                     VEHIDSVMGMIGVLPDMTPSTEMSMRGIRVSKMGVDEYSSTERVVVSIDRFLRVRDQR
+                     GNVLLSPEEVSETQGTERLTITYSSSMMWEINGPESVLVNTYQWIIRNWEAVKIQWSQ
+                     NPAMLYNKMEFEPFQSLVPKAIRSQYSGFVRTLFQQMRDVLGTFDTTQIIKLLPFAAA
+                     PPKQSRMQFSSLTVNVRGSGMRILVRGNSPVFNYNKTTKRLTILGKDAGTLIEDPDES
+                     TSGVESAVLRGFLIIGKEDRRYGPALSITELSNLAKGEKANVLIGQGDVVLVMKRKRD
+                     SSILTDSQTATKRIRMAIN"
+ORIGIN      
+        1 gtatggaaag aataaaagaa ctacggaatc tgatgtcgca gtctcgcact cgcgagatac
+       61 tgacaaaaac cacagtggac catatggcca taattaagaa gtacacatcg gggagacagg
+      121 aaaagaaccc gtcacttagg atgaaatgga tgatggcaat gaaataccca atcactgctg
+      181 acaaaaggat aacagaaatg gttccggaga gaaatgaaca aggacaaacc ctatggagta
+      241 aaatgagtga tgctggatca gatagagtga tggtatcacc tttggctgta acatggtgga
+      301 atagaaatgg acccgtgaca agtacggtcc attacccaaa agtgtacaag acttatttcg
+      361 acaaagtcga aaggttaaaa catggaacct ttggccctgt tcattttaga aatcaagtca
+      421 agatacgcag aagagtagac ataaaccctg gtcatgcaga cctcagtgcc aaagaggcac
+      481 aagatgtaat tatggaagtt gtttttccca atgaagtggg agccaggata ctaacatcag
+      541 aatcacaatt aacaataact aaagagaaaa aagaagaact ccgagattgc aaaatttctc
+      601 ccttgatggt tgcatacatg ttagagagag aacttgtacg aaaaacaaga tttctcccag
+      661 ttgctggcgg aacaagcagt atatacattg aagttttaca tttgactcag ggaacgtgtt
+      721 gggaacaaat gtacactcca ggtggaggag tgaggaatga cgatgttgac caaagcctaa
+      781 ttattgcggc caggaacata gtaagaagag ccgcagtatc agcagatcca ctagcatctt
+      841 tattggagat gtgccacagc acacaaattg gcggaacaag gatggtggac attcttagac
+      901 agaacccgac tgaagaacaa gctgtggata tatgcaaggc tgcaatggga ttgagaatca
+      961 gctcatcctt cagctttggt gggtttacat ttaaaagaac aagcgggtca tcagtcaaaa
+     1021 aagaagaaga ggtgcttaca ggcaatctcc aaacattgag aataagagta catgaggggt
+     1081 atgaggagtt cacaatggtt gggaaaagag caacggctat actaagaaaa gcaaccagaa
+     1141 gattggttca actcatagtg agtggaagag acgaacagtc aatagccgaa gcaataatcg
+     1201 tggccatggt gttttcacaa gaagattgca tgataaaagc agttagaggt gacctgaatt
+     1261 tcgtcaacag agcaaatcag cggttgaacc ccatgcatca gcttttaagg cattttcaga
+     1321 aagatgcgaa agtgctcttt caaaattggg gagttgaaca catcgacagt gtgatgggga
+     1381 tgattggagt attaccagat atgactccaa gcacagagat gtcaatgaga ggaataagag
+     1441 tcagcaaaat gggtgtggat gaatactcca gtacagagag ggtggtggtt agcattgatc
+     1501 ggtttttgag agttcgagac caacgtggga atgtattatt atctcctgag gaggtcagtg
+     1561 aaacacaggg aactgagaga ctgacaataa cttattcatc gtcgatgatg tgggaaatta
+     1621 acggtcctga gtcggttttg gtcaatacct atcaatggat catcagaaat tgggaagctg
+     1681 tcaaaattca atggtctcag aatcctgcaa tgttgtacaa caaaatggaa tttgaaccat
+     1741 ttcaatcttt agtccccaag gccattagaa gccaatacag tgggtttgtc agaactctat
+     1801 tccaacaaat gagagacgta cttgggacat ttgacaccac ccagataata aagcttctcc
+     1861 cttttgcagc tgctccacca aagcaaagca gaatgcagtt ctcttcactg actgtgaatg
+     1921 taaggggatc agggatgaga atacttgtaa ggggcaattc tcctgtattc aactacaaca
+     1981 agaccactaa aagactaaca attctcggaa aagatgccgg cactttaatt gaagacccag
+     2041 atgaaagcac atccggagtg gagtccgccg tcttgagagg gtttctcatt ataggtaagg
+     2101 aagacagaag gtacggacca gcattaagca tcactgaact gagtaacctt gcaaaagggg
+     2161 aaaaggctaa tgtgctaatc gggcaaggag acgtggtgtt ggtaatgaaa cgaaaacgag
+     2221 actctagcat acttactgac agccagacag cgaccaaaag aattcggatg gccatcaatt
+     2281 aatgctgaat ag
 //

--- a/scripts/create_ref_genome.py
+++ b/scripts/create_ref_genome.py
@@ -14,6 +14,16 @@ def concat(files):
             flu_ref = seq
         else:
             flu_ref += seq
+    ha = SeqIO.read(files[0], 'gb')
+    descrip = ha.annotations['source']
+    name = descrip.split('(', 2)[1]
+    #Genbank forces names to be 16 characters or less.
+    if 'California' in name:
+        flu_ref.name = name.replace('California', 'Cali')
+    else:
+        flu_ref.name = name
+    flu_ref.description = descrip
+    flu_ref.id = descrip
     return flu_ref
 
 if __name__ == '__main__':
@@ -26,5 +36,5 @@ if __name__ == '__main__':
     parser.add_argument('--output', type = str, required = True, help = "output location")
     args = parser.parse_args()
 
-#Writes out reference genbank file for full influenza genome     
+# Writes out reference genbank file for full influenza genome     
 SeqIO.write(concat(args.references), args.output, 'gb')

--- a/scripts/create_ref_genome.py
+++ b/scripts/create_ref_genome.py
@@ -28,4 +28,3 @@ if __name__ == '__main__':
 
 #Writes out reference genbank file for full influenza genome     
 SeqIO.write(concat(args.references), args.output, 'gb')
-© 2019 GitHub, Inc.

--- a/scripts/create_ref_genome.py
+++ b/scripts/create_ref_genome.py
@@ -14,16 +14,6 @@ def concat(files):
             flu_ref = seq
         else:
             flu_ref += seq
-    ha = SeqIO.read(files[0], 'gb')
-    descrip = ha.annotations['source']
-    name = descrip.split('(', 2)[1]
-    #Genbank forces names to be 16 characters or less.
-    if 'California' in name:
-        flu_ref.name = name.replace('California', 'Cali')
-    else:
-        flu_ref.name = name
-    flu_ref.description = descrip
-    flu_ref.id = descrip
     return flu_ref
 
 if __name__ == '__main__':
@@ -36,5 +26,6 @@ if __name__ == '__main__':
     parser.add_argument('--output', type = str, required = True, help = "output location")
     args = parser.parse_args()
 
-# Writes out reference genbank file for full influenza genome     
+#Writes out reference genbank file for full influenza genome     
 SeqIO.write(concat(args.references), args.output, 'gb')
+© 2019 GitHub, Inc.


### PR DESCRIPTION
This commit should address #9 & #10. I swapped out all reference genomes for H3N2 for A/Perth/16/2009 segments, and I also updated the script `create_ref_genome.py` to add header information for `reference_{lineage}_genome.gb`.