### PR TITLE
Optional Filtering-to-region

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -531,7 +531,8 @@ checkpoint clusters_fasta:
         nt_muts = expand("results/nt-muts_{{lineage}}_{segment}_{{resolution}}.json", segment=segments),
         metadata = expand("data/metadata_{{lineage}}_{segment}.tsv", segment = segments)
     params:
-        min_size = 2
+        min_size = 2,
+        filter_to_region = "seattle"
     output:
         dir = directory("results/clusters/pre_{lineage}_genome_{resolution}")
     shell:
@@ -541,6 +542,7 @@ checkpoint clusters_fasta:
             --nt-muts {input.nt_muts} \
             --metadata {input.metadata} \
             --min-size {params.min_size} \
+            --filter-to-region {params.filter_to_region} \
             --output-dir {output.dir}
         """
 


### PR DESCRIPTION
This is in response to #18

I changed `extract_cluster_fasta` in order to make `--metadata` be an optional requirement and to allow it to take an additional optional parameter `filter-to-region` where defining a specific region via bash command will filter to only those clusters that contain at least one strain from that region.  I was unsure if you wanted me to include `filter-to-region` as a params in the Snakefile so it's currently set up to be included as a bash command but I can change if needed. 

_TB edit: like this:_
_Closes #18._