### PR TITLE
Updates feature>source for reference genbank files

### DIFF
--- a/scripts/create_ref_genome.py
+++ b/scripts/create_ref_genome.py
@@ -3,6 +3,7 @@ Concatenates segment reference genbank files into a genome reference genbank fil
 '''
 import argparse
 from Bio import SeqIO
+from Bio.SeqFeature import SeqFeature, FeatureLocation
 
 '''
 Creates full-genome Bio Seq object
@@ -23,6 +24,12 @@ def concat(files, reference):
 
     flu_ref.description = reference
     flu_ref.id = reference
+
+    #Adds source feature to Genbank file for the full-length of genome.
+    source_feature = flu_ref.features[0]
+    full_genome_feature = SeqFeature(FeatureLocation(0, len(flu_ref), strand = 1), type = "source", qualifiers = source_feature.qualifiers)
+    flu_ref.features.insert(0, full_genome_feature)
+
     return flu_ref
 
 if __name__ == '__main__':

--- a/scripts/create_ref_genome.py
+++ b/scripts/create_ref_genome.py
@@ -26,14 +26,23 @@ def concat(files, reference):
     flu_ref.id = reference
 
     #Adds source feature to Genbank file for the full-length of genome.
-    source_feature = flu_ref.features[0]
-    full_genome_feature = SeqFeature(FeatureLocation(0, len(flu_ref), strand = 1), type = "source", qualifiers = source_feature.qualifiers)
+    model_source_feature = flu_ref.features[0]
+    full_genome_feature = SeqFeature(FeatureLocation(0, len(flu_ref), strand = 1), type = "source", qualifiers = model_source_feature.qualifiers)
     #Removes qualifiers that don't apply to the entire sequence.
     if "segment" in full_genome_feature.qualifiers.keys():
         del full_genome_feature.qualifiers["segment"]
     if "lab_host" in full_genome_feature.qualifiers.keys():
         del full_genome_feature.qualifiers["lab_host"]
     flu_ref.features.insert(0, full_genome_feature)
+
+    #Removes features of type source that don't encompass whole genome.
+    source_features = []
+    for feature in flu_ref.features:
+        if feature.type == "source" and flu_ref.features.index(feature) != 0:
+            source_features.append(flu_ref.features.index(feature))
+    source_features.reverse()
+    for index in source_features:
+        flu_ref.features.pop(index)
 
     return flu_ref
 

--- a/scripts/create_ref_genome.py
+++ b/scripts/create_ref_genome.py
@@ -28,6 +28,11 @@ def concat(files, reference):
     #Adds source feature to Genbank file for the full-length of genome.
     source_feature = flu_ref.features[0]
     full_genome_feature = SeqFeature(FeatureLocation(0, len(flu_ref), strand = 1), type = "source", qualifiers = source_feature.qualifiers)
+    #Removes qualifiers that don't apply to the entire sequence.
+    if "segment" in full_genome_feature.qualifiers.keys():
+        del full_genome_feature.qualifiers["segment"]
+    if "lab_host" in full_genome_feature.qualifiers.keys():
+        del full_genome_feature.qualifiers["lab_host"]
     flu_ref.features.insert(0, full_genome_feature)
 
     return flu_ref


### PR DESCRIPTION
This should fix #16 by updating `create_ref_genome.py`. 

It uses the first source feature as a model to create as source feature spanning the entire length of the genome. Next, it removes qualifiers that don't apply to the entire genome. Finally, it deletes all other source features.

_Closes #16_