### PR TITLE
Download SFS metadata and sequences from ID3C

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -96,26 +96,11 @@ rule download_seattle_metadata:
         """
     output:
         metadata = "data/seattle_metadata.tsv"
-    run:
-        import requests
-        import json
-        import csv
-        from urllib.parse import urljoin
-
-        id3c_url = urljoin(os.environ["ID3C_URL"], "v1/shipping/augur-build-metadata")
-        id3c_username = os.environ["ID3C_USERNAME"]
-        id3c_password = os.environ["ID3C_PASSWORD"]
-
-        r = requests.get(id3c_url, auth=(id3c_username, id3c_password), stream=True)
-        stream = r.iter_lines()
-
-        with open(output.metadata, 'w+') as tsv_file:
-            tsv_writer = csv.writer(tsv_file, delimiter='\t')
-            for i, record in enumerate(map(json.loads, stream)):
-                # Write the TSV header
-                if i == 0:
-                    tsv_writer.writerow(record.keys())
-                tsv_writer.writerow(record.values())
+    shell:
+        """
+        python3 scripts/download_sfs_metadata.py \
+            --output {output.metadata}
+        """
 
 
 rule download_seattle_sequences:

--- a/Snakefile
+++ b/Snakefile
@@ -121,22 +121,17 @@ rule download_seattle_metadata:
 rule download_seattle_sequences:
     message:
         """
-        download_seattle_sequences: Downloading Seattle sequences from fauna
+        download_seattle_sequences: Downloading Seattle sequences from ID3C
         {wildcards.lineage} {wildcards.segment}
         """
     output:
         sequences = "data/seattle_sequences_{lineage}_{segment}.fasta"
-    params:
-        fasta_fields = "strain"
     shell:
         """
-        python3 {path_to_fauna}/vdb/download.py \
-            --database vdb \
-            --virus seattle \
-            --fasta_fields {params.fasta_fields} \
-            --select segment:{wildcards.segment} type:{wildcards.lineage} \
-            --path data \
-            --fstem seattle_sequences_{wildcards.lineage}_{wildcards.segment}
+        python3 scripts/download_sfs_sequences.py \
+            --output {output.sequences} \
+            --lineage {wildcards.lineage} \
+            --segment {wildcards.segment}
         """
 
 rule concat_sequences:

--- a/scripts/download_sfs_metadata.py
+++ b/scripts/download_sfs_metadata.py
@@ -1,0 +1,34 @@
+import os
+import argparse
+import json
+import csv
+from urllib.parse import urljoin
+import requests
+
+def get_metadata_from_id3c(id3c_url, id3c_username, id3c_password, output):
+    r = requests.get(id3c_url, auth=(id3c_username, id3c_password), stream=True)
+    stream = r.iter_lines()
+
+    with open(output, 'w+') as tsv_file:
+        tsv_writer = csv.writer(tsv_file, delimiter='\t')
+        for i, record in enumerate(map(json.loads, stream)):
+            # Write the TSV header
+            if i == 0:
+                tsv_writer.writerow(record.keys())
+            tsv_writer.writerow(record.values())
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description = "Downloads SFS metadata from ID3C",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("--output", type = str, default="data/seattle_metadata.tsv",
+        help="The output file for metadata, expected to be TSV file")
+    args = parser.parse_args()
+
+    id3c_url = urljoin(os.environ["ID3C_URL"], "v1/shipping/augur-build-metadata")
+    id3c_username = os.environ["ID3C_USERNAME"]
+    id3c_password = os.environ["ID3C_PASSWORD"]
+
+    get_metadata_from_id3c(id3c_url, id3c_username, id3c_password, args.output)

--- a/scripts/download_sfs_sequences.py
+++ b/scripts/download_sfs_sequences.py
@@ -1,0 +1,68 @@
+import requests
+import argparse
+import json
+import os
+from urllib.parse import urljoin
+
+
+def get_full_lineage(short_lineage):
+    """
+    Given a *short_lineage*, return the full lineage required to find exact
+    lineage match within ID3C.
+    """
+    lineage_map = {
+        'h1n1pdm': 'Influenza.A.H1N1',
+        'h3n2': 'Influenza.A.H3N2',
+        'vic': 'Influenza.B.Vic',
+        'yam': 'Influenza.B.Yam'
+    }
+
+    return lineage_map[short_lineage]
+
+
+def generate_full_url(base_url, lineage, segment):
+    """
+    Generate the full URL for the API endpoint to get sequences of a specific
+    *lineage* and *segment*
+    """
+    params = "/".join([lineage, segment])
+    return urljoin(base_url, params)
+
+
+def get_sequences_from_id3c(url, username, password, lineage, segment, output):
+    """
+    GET sequences from ID3C server with provided *lineage* and *segment*
+    """
+    r = requests.get(url, auth=(username,password), stream=True)
+
+    with open(output, 'w+') as fasta_file:
+        for line in r.iter_lines():
+            if line:
+                sequence = json.loads(line)
+                fasta_file.write("".join([">", sequence['sample'], "\n", sequence['seq'].lower(), "\n"]))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Downloads SFS sequences from ID3C of given lineage and segment",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("--output", type = str,
+                        help="The output file for sequences, expected to be FASTA file")
+    parser.add_argument("--lineage", type = str,
+                        help="The lineage wildcard from Snakefile")
+    parser.add_argument("--segment", type = str,
+                        help="The segment wildcard from Snakefile")
+
+    args = parser.parse_args()
+
+    id3c_url = urljoin(os.environ["ID3C_URL"], "v1/shipping/genomic-data/")
+    id3c_username = os.environ["ID3C_USERNAME"]
+    id3c_password = os.environ["ID3C_PASSWORD"]
+
+    lineage = get_full_lineage(args.lineage)
+    url = generate_full_url(id3c_url, lineage, args.segment)
+
+    get_sequences_from_id3c(url, id3c_username, id3c_password,
+                            lineage, args.segment, args.output)


### PR DESCRIPTION
This PR is dependent on https://github.com/seattleflu/id3c/pull/60 and https://github.com/seattleflu/id3c-customizations/pull/5. Once those changes are deployed, we will probably create a user for augur-build to have access to  ID3C. 

Adds scripts to download metadata and sequences directly from ID3C via API endpoint. 
Requires 3 environmental variables:
1. `ID3C_URL`
2. `ID3C_USERNAME`
3. `ID3C_PASSWORD` 
