### PR TITLE
Fix hidden node annotation script for v2 JSONs

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -27,8 +27,8 @@ def reference_strain(wildcards):
 
 rule all:
     input:
-        auspice_json = expand("auspice/seattleflu_flu_seasonal_{lineage}_{segment}_{resolution}.json", lineage=lineages, segment=segments, resolution=resolutions),
-        auspice_aggregated_json = expand("auspice/seattleflu_flu_seasonal_{lineage}_genome_{resolution}.json", lineage=lineages, resolution=resolutions)
+        auspice_json = expand("auspice/flu_seasonal_{lineage}_{segment}_{resolution}.json", lineage=lineages, segment=segments, resolution=resolutions),
+        auspice_aggregated_json = expand("auspice/flu_seasonal_{lineage}_genome_{resolution}.json", lineage=lineages, resolution=resolutions)
 
 rule files:
     params:
@@ -510,7 +510,7 @@ rule export:
         description = files.description,
         node_data = _get_node_data_for_export
     output:
-        auspice_json = "auspice/seattleflu_flu_seasonal_{lineage}_{segment}_{resolution}.json"
+        auspice_json = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}.json"
     shell:
         """
         augur export v2 \
@@ -904,7 +904,7 @@ rule hide_nodes_aggregated:
     input:
         auspice_json = rules.export_aggregated.output.auspice_json
     output:
-        auspice_json = "auspice/seattleflu_flu_seasonal_{lineage}_genome_{resolution}.json"
+        auspice_json = "auspice/flu_seasonal_{lineage}_genome_{resolution}.json"
     shell:
         """
         python scripts/annotate_hidden_nodes.py \

--- a/Snakefile
+++ b/Snakefile
@@ -27,8 +27,8 @@ def reference_strain(wildcards):
 
 rule all:
     input:
-        auspice_json = expand("auspice/flu_seasonal_{lineage}_{segment}_{resolution}.json", lineage=lineages, segment=segments, resolution=resolutions),
-        auspice_aggregated_json = expand("auspice/flu_seasonal_{lineage}_genome_{resolution}.json", lineage=lineages, resolution=resolutions)
+        auspice_json = expand("auspice/seattleflu_flu_seasonal_{lineage}_{segment}_{resolution}.json", lineage=lineages, segment=segments, resolution=resolutions),
+        auspice_aggregated_json = expand("auspice/seattleflu_flu_seasonal_{lineage}_genome_{resolution}.json", lineage=lineages, resolution=resolutions)
 
 rule files:
     params:
@@ -510,7 +510,7 @@ rule export:
         description = files.description,
         node_data = _get_node_data_for_export
     output:
-        auspice_json = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}.json"
+        auspice_json = "auspice/seattleflu_flu_seasonal_{lineage}_{segment}_{resolution}.json"
     shell:
         """
         augur export v2 \
@@ -881,7 +881,7 @@ rule export_aggregated:
         description = files.description,
         node_data = _get_node_data_for_export_aggregated
     output:
-        auspice_json = "auspice/flu_seasonal_{lineage}_genome_{resolution}.json"
+        auspice_json = "results/aggregated/seattle_flu_seasonal_{lineage}_genome_{resolution}.json"
     shell:
         """
         augur export v2 \
@@ -895,22 +895,22 @@ rule export_aggregated:
             --output {output.auspice_json}
         """
 
-# rule hide_nodes_aggregated:
-#     message:
-#         """
-#         hide_nodes_aggregated: Hide basal reassortant nodes in auspice JSON
-#         {wildcards.lineage} {wildcards.resolution}
-#         """
-#     input:
-#         auspice_json = rules.export_aggregated.output.auspice_json
-#     output:
-#         auspice_json = "auspice/seattleflu_flu_seasonal_{lineage}_genome_{resolution}.json"
-#     shell:
-#         """
-#         python scripts/annotate_hidden_nodes.py \
-#             --input {input.auspice_json} \
-#             --output {output.auspice_json}
-#         """
+rule hide_nodes_aggregated:
+    message:
+        """
+        hide_nodes_aggregated: Hide basal reassortant nodes in auspice JSON
+        {wildcards.lineage} {wildcards.resolution}
+        """
+    input:
+        auspice_json = rules.export_aggregated.output.auspice_json
+    output:
+        auspice_json = "auspice/seattleflu_flu_seasonal_{lineage}_genome_{resolution}.json"
+    shell:
+        """
+        python scripts/annotate_hidden_nodes.py \
+            --input {input.auspice_json} \
+            --output {output.auspice_json}
+        """
 
 rule clean:
     message: "Removing directories: {params}"


### PR DESCRIPTION
This commit (a) updates `scripts/annotate_hidden_nodes.py` to be compatible with v2 JSONs and (b) restores the Snakemake file to the state of  968471d. 

Script changes are relatively minor and reflect the updated syntax of v2 JSONs.

P.S. @trvrb I have not tested the Snakemake file here, but I believe it should work.

---

Note that `augur export v2` will interpret "hidden" nodes via node-data JSONs, but that only gets us half way. The approach taken in this repo does 2 more things: 
1. Creates "stubs" which are short branches leading to each cluster (see the magic parameters which have been made more explicit in this PR) 
2. Shifts the date & divergence values of hidden nodes so that the non-hidden nodes take up the entire screen in auspice. (Auspice calculates the view based on all the nodes, whether they are hidden or not, so a deep MRCA -- even if hidden -- doesn't look great.)

I'll do some thinking about how hidden nodes are best set in augur more generally, but for the purposes of this repo this PR achieves the desired result. 